### PR TITLE
better logic in init + tests

### DIFF
--- a/dataquality/core/init.py
+++ b/dataquality/core/init.py
@@ -1,21 +1,23 @@
 import os
+import warnings
 from typing import Dict, List, Optional
 
 import requests
 from pydantic.types import UUID4
 
+from dataquality import config
 from dataquality.core.auth import _Auth
-from dataquality.core.config import Config, config
 from dataquality.core.log import JsonlLogger
+from dataquality.exceptions import GalileoException
 from dataquality.schemas import Route
 from dataquality.utils.auth import headers
 from dataquality.utils.name import random_name
 
 
 class _Init:
-    def create_project(self, data: Dict, config: Config) -> Dict:
+    def create_project(self, data: Dict) -> Dict:
         if not config.token:
-            raise Exception("Token not present, please log in!")
+            raise GalileoException("Token not present, please log in!")
         req = requests.post(
             f"{config.api_url}/{Route.projects}",
             json=data,
@@ -23,9 +25,9 @@ class _Init:
         )
         return req.json()
 
-    def create_project_run(self, project_id: UUID4, data: Dict, config: Config) -> Dict:
+    def create_project_run(self, project_id: UUID4, data: Dict) -> Dict:
         if not config.token:
-            raise Exception("Token not present, please log in!")
+            raise GalileoException("Token not present, please log in!")
         req = requests.post(
             f"{config.api_url}/{Route.projects}/{project_id}/runs",
             json=data,
@@ -33,43 +35,61 @@ class _Init:
         )
         return req.json()
 
-    def get_user_projects(self, user_id: UUID4) -> List[Dict]:
-        if not config.token:
-            raise Exception("Token not present, please log in!")
+    def get_user_projects(self) -> List[Dict]:
+        user_id = self.get_user_id()
         req = requests.get(
             f"{config.api_url}/{Route.users}/{user_id}/projects",
             headers=headers(config.token),
         )
         return req.json()
 
-    def get_project_by_name_for_user(self, user_id: UUID4, project_name: str) -> Dict:
-        projects = self.get_user_projects(user_id)
-        return [project for project in projects if project["name"] == project_name][0]
+    def get_project_by_name_for_user(self, project_name: str) -> Dict:
+        projects = self.get_user_projects()
+        name_project = {project["name"]: project for project in projects}
+        return name_project.get(project_name, {})
 
-    def get_run_from_project(
-        self, config: Config, project_id: UUID4, run_id: UUID4
+    def get_runs_from_project_for_user(self, project_name: str) -> Dict:
+        """Gets the runs for a given project for a given user"""
+        project = self.get_project_by_name_for_user(project_name)
+        if not project:
+            return {}
+        pid = project.get("id")
+        req = requests.get(
+            f"{config.api_url}/{Route.projects}/{pid}/runs",
+            headers=headers(config.token),
+        )
+        return req.json()
+
+    def get_project_run_by_name_for_user(
+        self, project_name: str, run_name: str
     ) -> Dict:
+        runs = self.get_runs_from_project_for_user(project_name)
+        name_run = {run["name"]: run for run in runs}
+        return name_run.get(run_name, {})
+
+    def get_run_from_project(self, project_id: UUID4, run_id: UUID4) -> Dict:
         if not config.token:
-            raise Exception("Token not present, please log in!")
+            raise GalileoException("Token not present, please log in!")
         return requests.get(
             f"{config.api_url}/{Route.projects}/{project_id}/runs/{run_id}",
             headers=headers(config.token),
         ).json()
 
-    def get_user_id(self, _auth: _Auth, config: Config) -> UUID4:
+    def get_user_id(self) -> UUID4:
+        if not config.token:
+            raise GalileoException("Token not present, please log in!")
+        _auth = _Auth(config=config, auth_method=config.auth_method)
         return _auth.get_current_user(config)["id"]
 
-    def _initialize_new_project(self, config: Config, project_name: str) -> Dict:
+    def _initialize_new_project(self, project_name: str) -> Dict:
         print(f"✨ Initializing project {project_name}")
         body = {"name": project_name}
-        return self.create_project(body, config)
+        return self.create_project(body)
 
-    def _initialize_run_for_project(
-        self, config: Config, project_id: UUID4, run_name: str
-    ) -> Dict:
+    def _initialize_run_for_project(self, project_id: UUID4, run_name: str) -> Dict:
         print(f"🏃‍♂️ Starting run {run_name}")
         body = {"name": run_name}
-        return self.create_project_run(project_id, body, config)
+        return self.create_project_run(project_id, body)
 
     def create_log_file_dir(self, project_id: UUID4, run_id: UUID4) -> None:
         write_output_dir = f"{JsonlLogger.LOG_FILE_DIR}/{project_id}/{run_id}"
@@ -77,31 +97,43 @@ class _Init:
             os.makedirs(write_output_dir)
 
 
-def init(project_name: Optional[str] = None, run_id: Optional[UUID4] = None) -> None:
-    _auth = _Auth(config=config, auth_method=config.auth_method)
+def init(project_name: Optional[str] = None, run_name: Optional[str] = None) -> None:
+    """
+    Start a run
+
+    Initialize a new run and new project, initialize a new run in an existing project,
+    or reinitialize an existing run in an existing project.
+
+    Optionally provide project and run names to create a new project/run or restart
+    existing ones.
+
+    :param project_name: The project name. If not passed in, a random one will be
+    generated. If provided, and the project does not exist, it will be created. If it
+    does exist, it will be set.
+    :param run_name: The run name. If not passed in, a random one will be
+    generated. If provided, and the project does not exist, it will be created. If it
+    does exist, it will be set.
+    """
     _init = _Init()
     config.labels = None
-    if project_name is None and run_id is None:
+    if not project_name and not run_name:
         # no project and no run id, start a new project and start a new run
         project_name, run_name = random_name(), random_name()
-        project_response = _init._initialize_new_project(
-            config=config, project_name=project_name
-        )
+        project_response = _init._initialize_new_project(project_name=project_name)
         run_response = _init._initialize_run_for_project(
-            config=config, project_id=project_response["id"], run_name=run_name
+            project_id=project_response["id"], run_name=run_name
         )
         config.current_project_id = project_response["id"]
         config.current_run_id = run_response["id"]
         print(f"🛰 Created project, {project_name}, and new run, {run_name}.")
-    elif project_name is not None and run_id is None:
-        user_id = _init.get_user_id(_auth, config)
-        project = _init.get_project_by_name_for_user(user_id, project_name)
+    elif project_name and not run_name:
+        project = _init.get_project_by_name_for_user(project_name)
         # if project exists, start new run
         if project.get("id") is not None:
             run_name = random_name()
             print(f"📡 Retrieved project, {project_name}, and starting a new run")
             run_response = _init._initialize_run_for_project(
-                config=config, project_id=project["id"], run_name=run_name
+                project_id=project["id"], run_name=run_name
             )
             config.current_project_id = project["id"]
             config.current_run_id = run_response["id"]
@@ -111,48 +143,52 @@ def init(project_name: Optional[str] = None, run_id: Optional[UUID4] = None) -> 
         # otherwise create project with given name and start new run
         else:
             print(f"💭 Project {project_name} was not found.")
-            project_name, run_name = random_name(), random_name()
-            project_response = _init._initialize_new_project(
-                config=config, project_name=project_name
-            )
+            run_name = random_name()
+            project_response = _init._initialize_new_project(project_name=project_name)
             run_response = _init._initialize_run_for_project(
-                config=config, project_id=project_response["id"], run_name=run_name
+                project_id=project_response["id"], run_name=run_name
             )
             config.current_project_id = project_response["id"]
             config.current_run_id = run_response["id"]
-    elif project_name is not None and run_id is not None:
-        # given a project and run, retrieve the data and set info to state
+    elif project_name and run_name:
+        # If the project and run exist, connect to them
         print(f"📡 Retrieving existing run from project, {project_name}")
-        user_id = _init.get_user_id(_auth, config)
-        project = _init.get_project_by_name_for_user(user_id, project_name)
+        project = _init.get_project_by_name_for_user(project_name)
         # if project actually exists, get the run
-        if project.get("id") is not None:
-            run = _init.get_run_from_project(
-                config=config, project_id=project["id"], run_id=run_id
+        if project.get("name"):
+            run = _init.get_project_run_by_name_for_user(
+                project["name"], run_name=run_name
             )
-            if run.get("id") is not None:
+            if run.get("id"):
                 config.current_project_id = project["id"]
                 config.current_run_id = run["id"]
-                print(
-                    f"🛰 Connected to project, {project_name}, and run, {run['name']}."
-                )
+                print(f"🛰 Connected to project, {project_name}, and run, {run_name}.")
             else:
-                print(
-                    f"⚠️ The Galileo account associated with {config.current_user}"
-                    f" does not have a run with id {run_id} "
-                    f"associated with the project {project_name}."
+                # If the run does not exist, create it
+                run_response = _init._initialize_run_for_project(
+                    project["id"], run_name
                 )
-                return
+                config.current_project_id = project["id"]
+                config.current_run_id = run_response["id"]
+                print(
+                    f"🛰 Connected to project, {project['name']} "
+                    f"and created new run, {run_name}."
+                )
         else:
-            print(
-                f"⚠️ The Galileo account associated with {config.current_user}"
-                f" does not have a project named {project_name}."
+            # User gave us a new project name and new run name to create, so create it
+            print(f"💭 Project {project_name} was not found.")
+            project_response = _init._initialize_new_project(project_name=project_name)
+            run_response = _init._initialize_run_for_project(
+                project_id=project_response["id"], run_name=run_name
             )
-            return
+            config.current_project_id = project_response["id"]
+            config.current_run_id = run_response["id"]
+            print(f"🛰 Created project, {project_name}, and new run, {run_name}.")
     else:
-        print(
-            "⚠️ You must specify a project name to initialize a new Galileo run"
-            " or simply run dataquality.init()."
+        # The user provided a run name and no project name. No good
+        warnings.warn(
+            "⚠️ You must specify a project name to initialize or create a new Galileo "
+            "run. Add a project name, or simply run dataquality.init()."
         )
         return
     config.update_file_config()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,13 +5,13 @@ import pytest
 
 import dataquality
 from dataquality.core.auth import GALILEO_AUTH_METHOD
-from tests.utils.mock_request import mocked_failed_requests, mocked_requests
+from tests.utils.mock_request import mocked_failed_login_requests, mocked_login_requests
 
 config = dataquality.config
 
 
-@mock.patch("requests.post", side_effect=mocked_requests)
-@mock.patch("requests.get", side_effect=mocked_requests)
+@mock.patch("requests.post", side_effect=mocked_login_requests)
+@mock.patch("requests.get", side_effect=mocked_login_requests)
 def test_good_login(*args) -> None:
     os.environ[GALILEO_AUTH_METHOD] = "email"
     os.environ["GALILEO_USERNAME"] = "user"
@@ -19,7 +19,7 @@ def test_good_login(*args) -> None:
     dataquality.login()
 
 
-@mock.patch("requests.post", side_effect=mocked_failed_requests)
+@mock.patch("requests.post", side_effect=mocked_failed_login_requests)
 def test_bad_login(mock_post) -> None:
     config.token = None
     os.environ[GALILEO_AUTH_METHOD] = "email"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,97 @@
+from unittest import mock
+
+import pytest
+
+import dataquality
+from dataquality import config
+from dataquality.exceptions import GalileoException
+from tests.utils.mock_request import (
+    EXISTING_PROJECT,
+    EXISTING_RUN,
+    mocked_create_project_run,
+    mocked_get_project_run,
+    mocked_missing_project_run,
+    mocked_missing_run,
+)
+
+
+@mock.patch("requests.post", side_effect=mocked_create_project_run)
+def test_init(*args) -> None:
+    """Base case: Tests creating a new project and run"""
+    config.token = "sometoken"
+    dataquality.init()
+    assert config.current_run_id
+    assert config.current_project_id
+
+
+@mock.patch("requests.post", side_effect=mocked_create_project_run)
+@mock.patch("requests.get", side_effect=mocked_get_project_run)
+def test_init_existing_project(*args) -> None:
+    """Tests calling init passing in an existing project"""
+    config.token = "sometoken"
+    config.current_project_id = config.current_run_id = None
+    dataquality.init(project_name=EXISTING_PROJECT)
+    assert config.current_run_id
+    assert config.current_project_id
+
+
+@mock.patch("requests.get", side_effect=mocked_missing_project_run)
+@mock.patch("requests.post", side_effect=mocked_create_project_run)
+def test_init_new_project(*args) -> None:
+    """Tests calling init passing in a new project"""
+    config.token = "sometoken"
+    config.current_project_id = config.current_run_id = None
+    dataquality.init(project_name="new_proj")
+    assert config.current_run_id
+    assert config.current_project_id
+
+
+@mock.patch("requests.get", side_effect=mocked_missing_run)
+@mock.patch("requests.post", side_effect=mocked_create_project_run)
+def test_init_existing_project_new_run(*args) -> None:
+    """Tests calling init with an existing project but a new run"""
+    config.token = "sometoken"
+    config.current_project_id = config.current_run_id = None
+    dataquality.init(project_name=EXISTING_PROJECT, run_name="new_run")
+    assert config.current_run_id
+    assert config.current_project_id
+
+
+@mock.patch("requests.get", side_effect=mocked_get_project_run)
+@mock.patch("requests.post", side_effect=mocked_get_project_run)
+def test_init_existing_project_run(*args) -> None:
+    """Tests calling init with an existing project and existing run"""
+    config.token = "sometoken"
+    config.current_project_id = config.current_run_id = None
+    dataquality.init(project_name=EXISTING_PROJECT, run_name=EXISTING_RUN)
+    assert config.current_run_id
+    assert config.current_project_id
+
+
+@mock.patch("requests.get", side_effect=mocked_missing_project_run)
+@mock.patch("requests.post", side_effect=mocked_create_project_run)
+def test_init_new_project_run(*args) -> None:
+    """Tests calling init with a new project and new run"""
+    config.token = "sometoken"
+    config.current_project_id = config.current_run_id = None
+    dataquality.init(project_name="new_proj", run_name="new_run")
+    assert config.current_run_id
+    assert config.current_project_id
+
+
+def test_init_only_run(*args) -> None:
+    """Tests calling init only passing in a run"""
+    config.token = "sometoken"
+    config.current_project_id = config.current_run_id = None
+    dataquality.init(run_name="a_run")
+    assert not config.current_run_id
+    assert not config.current_project_id
+
+
+@mock.patch("requests.get", side_effect=mocked_get_project_run)
+def test_init_no_login(*args) -> None:
+    config.token = None
+    with pytest.raises(GalileoException):
+        dataquality.init()
+    with pytest.raises(GalileoException):
+        dataquality.init(project_name=EXISTING_PROJECT)

--- a/tests/utils/mock_request.py
+++ b/tests/utils/mock_request.py
@@ -1,19 +1,24 @@
 from typing import Any, Dict
+from uuid import uuid4
 
 import dataquality
 
 config = dataquality.config
 
+EXISTING_PROJECT = "existing_proj"
+EXISTING_RUN = "existing_run"
 
-def mocked_requests(*args: Any, **kwargs: Dict[str, Any]):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
 
-        def json(self):
-            return self.json_data
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
 
+    def json(self):
+        return self.json_data
+
+
+def mocked_login_requests(*args: Any, **kwargs: Dict[str, Any]):
     if args[0].endswith("login"):
         return MockResponse({"access_token": "mock_token"}, 200)
 
@@ -23,16 +28,41 @@ def mocked_requests(*args: Any, **kwargs: Dict[str, Any]):
     return MockResponse(None, 200)
 
 
-def mocked_failed_requests(*args: Any, **kwargs: Dict[str, Any]):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-
-        def json(self):
-            return self.json_data
-
+def mocked_failed_login_requests(*args: Any, **kwargs: Dict[str, Any]):
     if args[0].endswith("login"):
         return MockResponse("Invalid credentials", 404)
 
     return MockResponse(None, 404)
+
+
+def mocked_get_project_run(*args: Any, **kwargs: Dict[Any, Any]):
+    if args[0].endswith("current_user"):
+        return MockResponse({"id": "user"}, 200)
+    res = [
+        {"id": uuid4(), "name": EXISTING_PROJECT},
+        {"id": uuid4(), "name": EXISTING_RUN},
+    ]
+    return MockResponse(res, 200)
+
+
+def mocked_create_project_run(*args: Any, **kwargs: Dict[Any, Any]):
+    res = {"id": uuid4(), "name": "existing"}
+    return MockResponse(res, 200)
+
+
+def mocked_missing_run(*args: Any, **kwargs: Dict[Any, Any]):
+    if args[0].endswith("current_user"):
+        return MockResponse({"id": "user"}, 200)
+    # Run does not exist
+    if args[0].endswith("runs"):
+        return MockResponse({}, 204)
+    # Project does exist
+    else:
+        res = {"id": uuid4(), "name": EXISTING_PROJECT}
+        return MockResponse([res], 200)
+
+
+def mocked_missing_project_run(*args: Any, **kwargs: Dict[Any, Any]):
+    if args[0].endswith("current_user"):
+        return MockResponse({"id": "user"}, 200)
+    return MockResponse({}, 204)


### PR DESCRIPTION
> **Please do not create a pull request without creating an issue first.**
>
> Changes need to be discussed before proceeding, pull requests submitted without linked issues may be rejected.
>
> Please provide enough information so that others can review your pull request. You can skip this if you're fixing a typo – it happens.

* [X] I have added tests to `tests` to cover my changes.


***What existing issue does this pull request close?***

Put `closes #issue-number` in this pull request's description to auto-close the issue that this fixes.

***How are these changes tested?***

pytest and jupyter notebook



***Provide additional context.***

The init function was untested and pretty confusing. I cleaned it up and added code coverage, and documentation. The new functionality. 

Now, the user can pass a `project_name` and `run_name` instead of needing a `run_id`

For both projects and runs, if the name already exists, they are connected to it. If not, that project/run is created. 
* existing project, new run - connected to project, new run created
* existing project, existing run - connected to project/run
* new project, new run - creates new project and run
* no run specified - random run name generated and created
* no project specified
* * if run specified, warning returned and no action
* * no run specified - new project and run created


![image](https://user-images.githubusercontent.com/22605641/141519061-85e34473-fea3-4875-a4ee-9b171ff84a53.png)
