### PR TITLE
Script to test dataquality client end to end without training a model

### DIFF
--- a/tests/integration/mock_training_run.py
+++ b/tests/integration/mock_training_run.py
@@ -24,10 +24,8 @@ os.environ["GALILEO_AUTH_METHOD"] = "email"
 os.environ["GALILEO_USERNAME"] = "adminy_guy@rungalileo.io"
 os.environ["GALILEO_PASSWORD"] = "Admin123@"
 import dataquality  # noqa
-from dataquality.core.integrations.config import (  # noqa
-    GalileoDataConfig,
-    GalileoModelConfig,
-)
+from dataquality.core.integrations.config import GalileoDataConfig  # noqa
+from dataquality.core.integrations.config import GalileoModelConfig  # noqa
 
 DATASET = "amazon_polarity"
 TRAIN_DATASET_NAME = f"{DATASET}_train.csv"


### PR DESCRIPTION
This way we can hopefully quickly iterate on performance optimizations.

Usage: `python model_training_run.py`
To change datasets change `DATASET` flag to something in this s3 bucket:
https://s3.console.aws.amazon.com/s3/buckets/galileo-ml-train?region=us-west-1&prefix=datasets/original/&showversions=false

amazon_polarity and agnews are two larger dataset at 3.6 mil and 120k each