### PR TITLE
housekeeping: remove args and kwargs in test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -21,7 +22,10 @@ api_client = ApiClient()
 
 @mock.patch("requests.get", side_effect=mocked_get_project_run)
 @mock.patch("requests.delete", side_effect=mocked_delete_project_run)
-def test_delete_project(*args) -> None:
+def test_delete_project(
+    mock_delete_run: MagicMock,
+    mock_get_run: MagicMock,
+) -> None:
     """Base case: Tests creating a new project and run"""
     config.token = "sometoken"
     api_client.delete_project(uuid4())
@@ -29,7 +33,10 @@ def test_delete_project(*args) -> None:
 
 @mock.patch("requests.get", side_effect=mocked_delete_project_not_found)
 @mock.patch("requests.delete", side_effect=mocked_delete_project_not_found)
-def test_delete_project_not_found(*args) -> None:
+def test_delete_project_not_found(
+    mock_delete_run: MagicMock,
+    mock_get_run: MagicMock,
+) -> None:
     """Base case: Tests creating a new project and run"""
     config.token = "sometoken"
     with pytest.raises(GalileoException):
@@ -38,14 +45,17 @@ def test_delete_project_not_found(*args) -> None:
 
 @mock.patch("requests.get", side_effect=mocked_get_project_run)
 @mock.patch("requests.delete", side_effect=mocked_delete_project_run)
-def test_delete_project_by_name(*args) -> None:
+def test_delete_project_by_name(
+    mock_delete_run: MagicMock,
+    mock_get_run: MagicMock,
+) -> None:
     """Base case: Tests creating a new project and run"""
     config.token = "sometoken"
     api_client.delete_project_by_name(EXISTING_PROJECT)
 
 
 @mock.patch("requests.get", side_effect=mocked_missing_project_name)
-def test_delete_project_by_name_not_found(*args) -> None:
+def test_delete_project_by_name_not_found(mock_get_run: MagicMock) -> None:
     """Base case: Tests creating a new project and run"""
     config.token = "sometoken"
     with pytest.raises(GalileoException):
@@ -54,7 +64,10 @@ def test_delete_project_by_name_not_found(*args) -> None:
 
 @mock.patch("requests.get", side_effect=mocked_get_project_run)
 @mock.patch("requests.delete", side_effect=mocked_delete_project_run)
-def test_delete_run(*args) -> None:
+def test_delete_run(
+    mock_delete_run: MagicMock,
+    mock_get_run: MagicMock,
+) -> None:
     """Base case: Tests creating a new project and run"""
     config.token = "sometoken"
     api_client.delete_run(uuid4(), uuid4())
@@ -62,7 +75,10 @@ def test_delete_run(*args) -> None:
 
 @mock.patch("requests.get", side_effect=mocked_get_project_run)
 @mock.patch("requests.delete", side_effect=mocked_delete_project_not_found)
-def test_delete_run_missing_run(*args) -> None:
+def test_delete_run_missing_run(
+    mock_delete_run: MagicMock,
+    mock_get_run: MagicMock,
+) -> None:
     """Base case: Tests creating a new project and run"""
     config.token = "sometoken"
     with pytest.raises(GalileoException):
@@ -71,14 +87,17 @@ def test_delete_run_missing_run(*args) -> None:
 
 @mock.patch("requests.get", side_effect=mocked_get_project_run)
 @mock.patch("requests.delete", side_effect=mocked_delete_project_run)
-def test_delete_run_by_name(*args) -> None:
+def test_delete_run_by_name(
+    mock_delete_run: MagicMock,
+    mock_get_run: MagicMock,
+) -> None:
     """Base case: Tests creating a new project and run"""
     config.token = "sometoken"
     api_client.delete_run_by_name(EXISTING_PROJECT, EXISTING_RUN)
 
 
 @mock.patch("requests.get", side_effect=mocked_missing_run)
-def test_delete_run_by_name_missing_run(*args) -> None:
+def test_delete_run_by_name_missing_run(mock_get_run: MagicMock) -> None:
     """Base case: Tests creating a new project and run"""
     config.token = "sometoken"
     with pytest.raises(GalileoException):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 import os
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -12,7 +13,10 @@ config = dataquality.config
 
 @mock.patch("requests.post", side_effect=mocked_login_requests)
 @mock.patch("requests.get", side_effect=mocked_login_requests)
-def test_good_login(*args) -> None:
+def test_good_login(
+    mock_get_current_user: MagicMock,
+    mock_login: MagicMock,
+) -> None:
     os.environ[GALILEO_AUTH_METHOD] = "email"
     os.environ["GALILEO_USERNAME"] = "user"
     os.environ["GALILEO_PASSWORD"] = "password"
@@ -21,7 +25,7 @@ def test_good_login(*args) -> None:
 
 
 @mock.patch("requests.post", side_effect=mocked_failed_login_requests)
-def test_bad_login(mock_post) -> None:
+def test_bad_login(mock_post: MagicMock) -> None:
     tok = config.token
     config.token = None
     os.environ[GALILEO_AUTH_METHOD] = "email"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -20,7 +21,7 @@ def test_get_client_version() -> None:
 
 
 @mock.patch("requests.get", side_effect=mocked_healthcheck_request)
-def test_get_api_version(*args) -> None:
+def test_get_api_version(mock_get_api_version: MagicMock) -> None:
     assert version._get_api_version() == __version__
 
 
@@ -33,12 +34,12 @@ def test_parse_version_beta() -> None:
 
 
 @mock.patch("requests.get", side_effect=mocked_healthcheck_request_new_api_version)
-def test_version_check_fail(*args) -> None:
+def test_version_check_fail(mock_get_healthcheck: MagicMock) -> None:
     with pytest.raises(GalileoException):
         version._version_check()
 
 
 @mock.patch("requests.get", side_effect=mocked_healthcheck_request)
-def test_version_check_pass(*args) -> None:
+def test_version_check_pass(mock_get_healthcheck: MagicMock) -> None:
     version._version_check()
     assert True


### PR DESCRIPTION
* [ ] I have added tests to `tests` to cover my changes.
* [ ] I have updated `docs/`, if necessary.
* [ ] I have updated the `README.md`, if necessary.

***What existing issue does this pull request close?***

No issue.

***How are these changes tested?***

Locally and in CI

***Demonstration***

N/A

***Provide additional context.***

Felt like a hypocrite after asking @elboy3 to not use args and kwargs so i wanted to dig around and remove args and kwargs that wouldnt cause immediate changes to product. types >>> args and kwargs!
