### PR TITLE
Default minio user secret to empty string

### DIFF
--- a/dataquality/core/auth.py
+++ b/dataquality/core/auth.py
@@ -43,7 +43,7 @@ class _Auth:
 
         access_token = res.json().get("access_token")
         config.token = access_token
-        minio_secret_key = res.json().get("minio_user_secret_access_key")
+        minio_secret_key = res.json().get("minio_user_secret_access_key", "")
         os.environ[GalileoConfigVars.MINIO_ACCESS_KEY] = username
         os.environ[GalileoConfigVars.MINIO_SECRET_KEY] = minio_secret_key
         config.update_file_config()


### PR DESCRIPTION
Gracefully handle edge case where user `minio_user_secret_access_key ` is None. Follow up of https://github.com/rungalileo/dataquality/pull/137

```python
>>> import os
>>> os.environ["MINIO_SECRET_KEY"] = None
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/elliottchartock/.pyenv/versions/3.9.6/lib/python3.9/os.py", line 684, in __setitem__
    value = self.encodevalue(value)
  File "/Users/elliottchartock/.pyenv/versions/3.9.6/lib/python3.9/os.py", line 756, in encode
    raise TypeError("str expected, not %s" % type(value).__name__)
TypeError: str expected, not NoneType
```