### PR TITLE
Small change to lint.sh, have black --check come before flake8

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
 mypy dataquality
-flake8 dataquality tests docs_src
 black dataquality tests docs_src --check
+flake8 dataquality tests docs_src
 isort dataquality tests docs_src --check-only


### PR DESCRIPTION
Since the suggestions black has often will fix flake8, I would propose we change the order? In my linting anyways I notice I go mypy, black, flake8, isort

> **Please do not create a pull request without creating an issue first.**
>
> Changes need to be discussed before proceeding, pull requests submitted without linked issues may be rejected.
>
> Please provide enough information so that others can review your pull request. You can skip this if you're fixing a typo – it happens.

* [ ] I have added tests to `tests` to cover my changes.
* [ ] I have updated `docs/`, if necessary.
* [ ] I have updated the `README.md`, if necessary.

***What existing issue does this pull request close?***

Put `closes #issue-number` in this pull request's description to auto-close the issue that this fixes.

***How are these changes tested?***

This pull request includes automated tests for the code it touches and those tests are described below. If no tests are included, reasons why must be provided below.

These changes are tested with [...]

***Demonstration***

Demonstrate your contribution.

For example, what are the exact commands you ran and their output, related screenshots, screen-recordings, test runs, anything that can showcase.

***Provide additional context.***

Provide as much relevant context as you like.
