### PR TITLE
Spacy Inference placeholder 'coming soon' message w/test

### DIFF
--- a/dataquality/core/integrations/spacy.py
+++ b/dataquality/core/integrations/spacy.py
@@ -299,9 +299,7 @@ class GalileoTransitionBasedParserModel(ThincModelWrapper):
                 "inference_name='some_name')` to continue."
             )
         helper_data = model_logger.log_helper_data
-        helper_data["logits"] = {
-            doc.user_data["id"]: [None] * len(doc) for doc in X
-        }
+        helper_data["logits"] = {doc.user_data["id"]: [None] * len(doc) for doc in X}
         helper_data["embs"] = {doc.user_data["id"]: [None] * len(doc) for doc in X}
         helper_data["spacy_states"] = defaultdict(list)
         helper_data["spacy_states_end_idxs"] = defaultdict(list)

--- a/tests/test_spacy_ner.py
+++ b/tests/test_spacy_ner.py
@@ -237,7 +237,9 @@ def test_long_sample(
     del nlp
 
 
-def test_inference_split_raises_warning(cleanup_after_use, set_test_config):
+def test_inference_split_raises_warning(
+    cleanup_after_use: Callable, set_test_config: Callable
+) -> None:
     """Tests that inference mode raises a warning and continues without dq client"""
     TextNERModelLogger.logger_config.reset()
     set_test_config(task_type=TaskType.text_ner)


### PR DESCRIPTION
Just a small warning message for inference that disables the galileo logger if someone is running their spacy language in inference mode.

* [x] I have added tests to `tests` to cover my changes.
* [ ] I have updated `docs/`, if necessary.
* [ ] I have updated the `README.md`, if necessary.

***What existing issue does this pull request close?***

Put `closes #issue-number` in this pull request's description to auto-close the issue that this fixes.

***How are these changes tested?***

This pull request includes automated tests for the code it touches and those tests are described below. If no tests are included, reasons why must be provided below.

These changes are tested with [...]

***Demonstration***

Demonstrate your contribution.

For example, what are the exact commands you ran and their output, related screenshots, screen-recordings, test runs, anything that can showcase.

***Provide additional context.***

Provide as much relevant context as you like.
