### PR TITLE
numpy 1.22.4 has hdf5 issues for vaex

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ requires = [
     "blake3==0.2.1",
     "spacy==3.2.1",
     "wrapt==1.13.3",
-    "scipy>=1.7.0"
+    "scipy>=1.7.0",
+    "numpy<1.22.4"  # https://github.com/vaexio/vaex/issues/2062
 ]
 
 [tool.flit.metadata.urls]


### PR DESCRIPTION
> **Please do not create a pull request without creating an issue first.**
>
> Changes need to be discussed before proceeding, pull requests submitted without linked issues may be rejected.
>
> Please provide enough information so that others can review your pull request. You can skip this if you're fixing a typo – it happens.


***Provide additional context.***

relates to https://github.com/vaexio/vaex/issues/2062
I don't know if this is a vaex issue or a numpy one
