### PR TITLE
Updating pyarrow package requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ test = [
     "torch==1.9.1",
     "transformers==4.11.3",
     "torchmetrics<0.8.0",
-    "tensorflow==2.8.0",
+    "tensorflow==2.9.1",
     "pytest-env==0.6.2"
 ]
 dev = [


### PR DESCRIPTION
Updated pyarrow package requirement from `==5.0.0` to `>=5.0.0`. I have tested with `pyarrow==8.0.0`, which is used by hugging face package `datasets` and it works fine! 

closes #290 