### PR TITLE
special logging case for huggingface dataset

### DIFF
--- a/dataquality/core/log.py
+++ b/dataquality/core/log.py
@@ -113,7 +113,7 @@ def log_dataset(
 
     Dataset provided must be an iterable that can be traversed row by row, and for each
     row, the fields can be indexed into either via string keys or int indexes. Pandas
-    and Vaex dataframes are also allowed.
+    and Vaex dataframes are also allowed, as well as HuggingFace Datasets
 
     valid examples:
         d = [

--- a/dataquality/loggers/base_logger.py
+++ b/dataquality/loggers/base_logger.py
@@ -31,6 +31,13 @@ try:
 except ImportError:
     TF_AVAILABLE = False
 
+try:
+    import datasets
+
+    HF_AVAILABLE = True
+except ImportError:
+    HF_AVAILABLE = False
+
 
 T = TypeVar("T", bound="BaseGalileoLogger")
 
@@ -166,6 +173,8 @@ class BaseGalileoLogger:
     @staticmethod
     def _convert_tensor_to_py(v: Any) -> Union[str, int]:
         """Converts pytorch and tensorflow tensors to strings or ints"""
+        if isinstance(v, (int, str)):
+            return v
         if TF_AVAILABLE:
             if isinstance(v, tf.Tensor):
                 v = v.numpy()
@@ -247,3 +256,9 @@ class BaseGalileoLogger:
         if cls.logger_config.exception:
             upload_dq_log_file()
             raise GalileoException(cls.logger_config.exception)
+
+    @classmethod
+    def is_hf_dataset(cls, df: Any) -> bool:
+        if HF_AVAILABLE:
+            return isinstance(df, datasets.Dataset)
+        return False

--- a/dataquality/loggers/data_logger/text_multi_label.py
+++ b/dataquality/loggers/data_logger/text_multi_label.py
@@ -169,6 +169,9 @@ class TextMultiLabelDataLogger(TextClassificationDataLogger):
 
     def _process_label(self, batches: DefaultDict, label: Any) -> DefaultDict:
         """In multi-label, label will be a list of strings instead of a string"""
+        # In binary multi-label, it will be a single string
+        if self.logger_config.binary:
+            return super()._process_label(batches, label)
         batches["label"].append(self._convert_tensor_ndarray(label).tolist())
         return batches
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ test = [
     "transformers==4.11.3",
     "torchmetrics<0.8.0",
     "tensorflow==2.9.1",
-    "pytest-env==0.6.2"
+    "pytest-env==0.6.2",
+    "datasets==2.2.2"
 ]
 dev = [
     "flake8==3.9.2",

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -2,6 +2,7 @@ from itertools import chain
 from typing import Callable, List
 from unittest import mock
 
+import datasets
 import numpy as np
 import pandas as pd
 import pytest
@@ -657,6 +658,7 @@ def test_log_data_sample(
         pd.DataFrame(NER_INPUT_DATA),
         vaex.from_dict(NER_INPUT_DATA),
         NER_INPUT_ITER,
+        datasets.Dataset.from_dict(NER_INPUT_DATA),
     ],
 )
 def test_log_dataset(

--- a/tests/test_text_classification.py
+++ b/tests/test_text_classification.py
@@ -1,6 +1,7 @@
 from typing import Callable
 from unittest import mock
 
+import datasets
 import numpy as np
 import pandas as pd
 import pytest
@@ -109,6 +110,13 @@ def test_log_data_sample(
                 "my_labels": ["A", "A", "B"],
                 "my_id": [1, 2, 3],
             }
+        ),
+        datasets.Dataset.from_dict(
+            dict(
+                my_text=["sample1", "sample2", "sample3"],
+                my_labels=["A", "A", "B"],
+                my_id=[1, 2, 3],
+            )
         ),
     ],
 )


### PR DESCRIPTION
> **Please do not create a pull request without creating an issue first.**
>
> Changes need to be discussed before proceeding, pull requests submitted without linked issues may be rejected.
>
> Please provide enough information so that others can review your pull request. You can skip this if you're fixing a typo – it happens.

* [X] I have added tests to `tests` to cover my changes.

***How are these changes tested?***

local + pytest

***Demonstration***


before this change (iterating 1 by 1)
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/22605641/171485886-8128a5c9-e0be-4b70-9496-713f09bbd658.png">

with the change
<img width="1041" alt="image" src="https://user-images.githubusercontent.com/22605641/171485929-6d0b2d64-7b12-48bf-ad47-cee9e5944a3d.png">


***Additional Context***
Looping through a huggingface dataset 1 by 1 is incredibly slow, as you can see below. Slicing through it in chunks is significantly faster. Since the `log_dataset` function has to iterate 1 by 1 (cases of tensorflow/pytorch tensors, for example), because not all iterators are slicable/subscriptable, we add some custom logic to slice through a huggingface dataset. This is similar to out custom behavior of a vaex/pandas dataframe. 

<img width="893" alt="image" src="https://user-images.githubusercontent.com/22605641/171486065-0e066043-9998-4848-a202-9be680b72b92.png">

