### PR TITLE
Fixes involve bug

### DIFF
--- a/dataquality/integrations/spacy.py
+++ b/dataquality/integrations/spacy.py
@@ -112,6 +112,7 @@ def watch(nlp: Language) -> None:
         )
 
     text_ner_logger_config.user_data["nlp"] = nlp
+    text_ner_logger_config.user_data["ner_config"] = nlp._pipe_configs["ner"]
     dataquality.set_labels_for_run(ner.move_names)  # type: ignore
     dataquality.set_tagging_schema(TaggingSchema.BILOU)
 
@@ -144,6 +145,7 @@ def unwatch(nlp: Language) -> None:
 
     pipe_index = nlp._get_pipe_index(before="galileo_ner")
     nlp._pipe_meta[name] = nlp.get_factory_meta(factory_name)
+    nlp._pipe_configs[name] = text_ner_logger_config.user_data["ner_config"]
     nlp._components.insert(pipe_index, (name, pipe_component))
 
     nlp.remove_pipe("galileo_ner")

--- a/tests/test_spacy_ner.py
+++ b/tests/test_spacy_ner.py
@@ -157,8 +157,9 @@ def test_unwatch(set_test_config):
     # This should be possible here
     pickle.dumps(nlp)
 
-    watch(nlp)
-    unwatch(nlp)
+    for _ in range(3):  # This should be possible multiple times
+        watch(nlp)
+        unwatch(nlp)
 
     unwatched_ner = nlp.get_pipe("ner")
     assert isinstance(unwatched_ner, EntityRecognizer)


### PR DESCRIPTION
Involve wasn't able to watch an unwatched model. This happened because in the process of unwatching we manually added and removed components from the spacy Language (nlp) but did not add the proper spacy component config into the Language.