### PR TITLE
check spacy noop

### DIFF
--- a/dataquality/integrations/spacy.py
+++ b/dataquality/integrations/spacy.py
@@ -16,7 +16,7 @@ from thinc.api import set_dropout_rate
 from wrapt import CallableObjectProxy
 
 import dataquality
-from dataquality import config, check_noop
+from dataquality import check_noop, config
 from dataquality.exceptions import GalileoException
 from dataquality.loggers.logger_config.text_ner import text_ner_logger_config
 from dataquality.loggers.model_logger.text_ner import TextNERModelLogger


### PR DESCRIPTION
***Provide additional context.***

Noticed that disabling the dataquality spacy integration with `GALILEO_DISABLED=True` wasn't working 
