### PR TITLE
support console- as well as console.

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -1,6 +1,6 @@
 "dataquality"
 
-__version__ = "v0.5.4"
+__version__ = "v0.5.2"
 
 import os
 import resource

--- a/dataquality/core/_config.py
+++ b/dataquality/core/_config.py
@@ -86,7 +86,9 @@ def set_platform_urls(console_url_str: str) -> None:
     if url_is_localhost(console_url_str):
         os.environ[GalileoConfigVars.API_URL] = "http://localhost:8088"
     else:
-        api_url = console_url_str.replace("console.", "api.").rstrip("/")
+        # some urls are set up as "console-xxx.domain instead of console.xxx.domain
+        sfx = "." if "console." in console_url_str else "-"
+        api_url = console_url_str.replace(f"console{sfx}", f"api{sfx}").rstrip("/")
         api_url = f"https://{api_url}" if not api_url.startswith("http") else api_url
         api_url = api_url.replace("http://", "https://")
         _validate_api_url(console_url_str, api_url)
@@ -119,7 +121,11 @@ def _check_console_url() -> None:
     """
     console_url = os.getenv(GalileoConfigVars.CONSOLE_URL)
     if console_url:
-        if "console." not in console_url and not url_is_localhost(console_url):
+        if (
+            "console." not in console_url
+            and "console-" not in console_url
+            and not url_is_localhost(console_url)
+        ):
             warnings.warn(
                 f"It seems your GALILEO_CONSOLE_URL ({console_url}) is invalid. "
                 f"Your console URL should have 'console.' in the url. Ignoring"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,12 @@ def test_console_url(set_test_config: Callable) -> None:
     assert cfg.api_url == "https://api.mytest.rungalileo.io"
 
 
+def test_console_url_dash(set_test_config: Callable) -> None:
+    os.environ["GALILEO_CONSOLE_URL"] = "https://console-mytest.rungalileo.io"
+    cfg = set_config()
+    assert cfg.api_url == "https://api-mytest.rungalileo.io"
+
+
 @pytest.mark.parametrize(
     "console_url",
     ["http://localhost:3000", "http://127.0.0.1:3000"],


### PR DESCRIPTION
changed `0.5.4` to `0.5.2` because the most current release is 0.5.1. I'll cut a release after this merge