### PR TITLE
One-liner for Huggingface Transformers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ tmp/
 *.ann
 tests/notebooks/dev/
 
+finetuned

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+fail_fast: true
+
+repos:
+  - repo: local
+    hooks:
+      - id: test-script
+        name: test-script
+        entry: bash "scripts/pre-commit.sh"
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/dataquality/integrations/transformers_trainer.py
+++ b/dataquality/integrations/transformers_trainer.py
@@ -1,0 +1,323 @@
+# Imports for the hook manager
+from queue import Queue
+from typing import Callable, Dict, Iterable, List, Optional, Union
+
+from datasets import Dataset
+from torch import Tensor
+from torch.nn import Module
+from torch.utils.hooks import RemovableHandle
+from transformers import Trainer
+from transformers.modeling_outputs import BaseModelOutput, TokenClassifierOutput
+from transformers.trainer_callback import TrainerCallback, TrainerControl, TrainerState
+from transformers.training_args import TrainingArguments
+
+import dataquality as dq
+from dataquality.exceptions import GalileoException
+from dataquality.schemas.split import Split
+from dataquality.schemas.task_type import TaskType
+from dataquality.utils.helpers import check_noop
+from dataquality.utils.transformers import (
+    add_id_to_signature_columns,
+    remove_id_collate_fn_wrapper,
+)
+
+Layer = Optional[Union[Module, str]]
+EmbeddingDim = Optional[Iterable[int]]
+
+
+# Trainer callback for Huggingface transformers Trainer library
+class DQCallback(TrainerCallback):
+    """
+    [`TrainerCallback`] that sends the logs to [Galileo](https://www.rungalileo.io/)
+    for each training training step.
+    """
+
+    def __init__(
+        self,
+        layer: Layer = None,
+        embedding_dim: EmbeddingDim = None,
+    ) -> None:
+        # Access the dq logger helper data
+        self.helper_data = dq.get_model_logger().logger_config.helper_data
+        self._initialized = False
+        # Hook manager for attaching hooks to the model
+        self.hook_manager = HookManager()
+        self.layer = layer
+        self.embedding_dim = embedding_dim
+
+    def _clear_logger_config_helper_data(self) -> None:
+        self.helper_data.clear()
+
+    def on_init_end(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs: Dict,
+    ) -> None:
+        """
+        Event called at the end of the initialization of the [`Trainer`].
+        """
+        self._clear_logger_config_helper_data()
+
+    def setup(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        kwargs: Dict,
+    ) -> None:
+        """Setup the callback
+        :param args: Training arguments
+        :param state: Trainer state
+        :param model: Model
+        :param kwargs: Keyword arguments (eval_dataloader, train_dataloader, tokenizer)
+        :return: None"""
+        # Attach hooks to the model
+        assert dq.config.task_type == TaskType.text_classification, GalileoException(
+            "dq client must be initialized for text classification. "
+            "For example: dq.init('text_classification')"
+        )
+        model: Module = kwargs["model"]
+        self._attach_hooks_to_model(model, self.layer)
+        train_dataloader = kwargs["train_dataloader"]
+        train_dataloader_ds = train_dataloader.dataset
+        if isinstance(train_dataloader_ds, Dataset):
+            assert "id" in train_dataloader_ds.column_names, GalileoException(
+                "Did you map IDs to your dataset before watching the model?\n"
+                "To add the id column with datasets. You can run:\n"
+                """`ds= dataset.map(lambda x, idx: {"id": idx},"""
+                " with_indices=True)`. The id (index) column is needed in "
+                "the dataset for logging"
+            )
+        else:
+            raise GalileoException(f"Unknown dataset type {type(train_dataloader_ds)}")
+        self._initialized = True
+
+    def on_train_begin(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs: Dict,
+    ) -> None:
+        """
+        Event called at the beginning of training. Attaches hooks to model.
+        :param args: Training arguments
+        :param state: Trainer state
+        :param control: Trainer control
+        :param kwargs: Keyword arguments (model, eval_dataloader, tokenizer...)
+        :return: None
+        """
+        if not self._initialized:
+            self.setup(args, state, kwargs)
+        dq.set_split(Split.training)  # 🔭🌕 Galileo logging
+
+    def on_epoch_begin(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs: Dict,
+    ) -> None:
+        state_epoch = state.epoch
+        if state_epoch is not None:
+            state_epoch = int(state_epoch)
+            dq.set_epoch(state_epoch)  # 🔭🌕 Galileo logging
+
+    def on_train_end(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs: Dict,
+    ) -> None:
+        dq.set_split(Split.validation)  # 🔭🌕 Galileo logging
+
+    def on_step_end(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs: Dict,
+    ) -> None:
+        """
+        Perform a training step on a batch of inputs.
+        Log the embeddings, ids and logits.
+        :param args: Training arguments
+        :param state: Trainer state
+        :param control: Trainer control
+        :param kwargs: Keyword arguments (including the model, inputs, outputs)
+        :return: None
+        """
+        # Log only if embedding exists
+
+        assert self.helper_data.get("embs") is not None, GalileoException(
+            "Embedding passed to the logger can not be logged"
+        )
+        assert self.helper_data.get("logits") is not None, GalileoException(
+            "Logits passed to the logger can not be logged"
+        )
+        assert self.helper_data.get("ids") is not None, GalileoException(
+            "Did you map IDs to your dataset before watching the model? You can run:\n"
+            "`ds= dataset.map(lambda x, idx: {'id': idx}, with_indices=True)`\n"
+            "id (index) column is needed in the dataset for logging"
+        )
+
+        # 🔭🌕 Galileo logging
+        dq.log_model_outputs(**self.helper_data)
+
+    def _attach_hooks_to_model(self, model: Module, layer: Layer) -> None:
+        """
+        Method to attach hooks to the model by using the hook manager
+        :param model: Model
+        :param model: pytorch model layer to attach hooks to
+        :return: None
+        """
+        self.hook_manager.attach_embedding_hook(model, layer, self._embedding_hook)
+        self.hook_manager.attach_hook(model, self._logit_hook)
+
+    def _embedding_hook(
+        self,
+        model: Module,
+        model_input: Tensor,
+        model_output: Union[BaseModelOutput, Tensor],
+    ) -> None:
+        """
+        Hook to extract the embeddings from the model
+        Keyword arguments won't be passed to the hooks and only to the ``forward``.
+        The hook can modify the input. User can either return a tuple or a
+        single modified value in the hook. We will wrap the value into a tuple
+        if a single value is returned(unless that value is already a tuple).
+        The hook will be called every time after :func:`forward` has computed an output.
+
+        :param model: Model pytorch model / layer
+        :param model_input: Input of the current layer
+        :param model_output: Output of the current layer
+        :return: None
+        """
+        if isinstance(model_output, Tensor):
+            output = model_output
+        elif hasattr(model_output, "last_hidden_state"):
+            output = model_output.last_hidden_state
+        output_detached = output.detach()
+        # If embedding has the CLS token, remove it
+        if self.embedding_dim is not None:
+            dim, index = self.embedding_dim
+            output_detached = output_detached.select(dim, index)
+        elif len(output_detached.shape) == 3:
+            # It is assumed that the CLS token is removed through this dimension
+            output_detached = output_detached[:, 0]
+        self.helper_data["embs"] = output_detached
+
+    def _logit_hook(
+        self,
+        model: Module,
+        model_input: Tensor,
+        model_output: Union[TokenClassifierOutput, Tensor],
+    ) -> None:
+        """
+        Hook to extract the logits from the model.
+        :param model: Model pytorch model
+        :param model_input: Model input of the current layer
+        :param model_output: Model output of the current layer
+        :return: None
+        """
+        if isinstance(model_output, Tensor):
+            logits = model_output
+        elif hasattr(model_output, "logits"):
+            logits = model_output.logits
+        self.helper_data["logits"] = logits.detach()
+
+
+class HookManager:
+    """
+    Manages hooks for models. Has the ability to find the layer automatically.
+    Otherwise the layer or the layer name needs to be provided.
+    """
+
+    # Stores all hooks to remove them from the model later.
+    hooks: List[RemovableHandle] = []
+
+    def get_embedding_layer_auto(self, model: Module) -> Module:
+        """
+        Use a scoring algorithm to find the embedding layer automatically
+        given a model. The higher the score the more likely it is the embedding layer.
+        """
+        name, layer = next(model.named_children())
+        print(f"Selected layer for the last hidden state embedding {name}")
+        return layer
+
+    def get_embedding_layer_by_name(self, model: Module, name: str) -> Module:
+        """
+        Iterate over each layer and stop once the the layer name matches
+        :param model: Model
+        :parm name: string
+        """
+        queue: Queue = Queue()
+        start = model.named_children()
+        queue.put(start)
+        layer_names = []
+        layer_names_str: str = ""
+        while not queue.empty():
+            named_children = queue.get()
+            for layer_name, layer_model in named_children:
+                layer_names.append(layer_name)
+                layer_names_str = ", ".join(layer_names)
+                if layer_name == name:
+                    print(
+                        f"Found layer {layer_name} in model layers: {layer_names_str}"
+                    )
+                    return layer_model
+                layer_model._get_name()
+                queue.put(layer_model.named_children())
+        raise GalileoException(
+            f"Layer could not be found in {layer_names_str}, "
+            "make sure to check capitalization"
+        )
+
+    def attach_embedding_hook(
+        self,
+        model: Module,
+        model_layer: Optional[Union[Module, str]] = None,
+        embedding_hook: Callable = print,
+    ) -> RemovableHandle:
+        """Attach hook and save it in our hook list"""
+        if model_layer is None:
+            selected_layer = self.get_embedding_layer_auto(model)
+        elif isinstance(model_layer, str):
+            selected_layer = self.get_embedding_layer_by_name(model, model_layer)
+        else:
+            selected_layer = model_layer
+        return self.attach_hook(selected_layer, embedding_hook)
+
+    def attach_hook(self, selected_layer: Module, hook: Callable) -> RemovableHandle:
+        """Register a hook and save it in our hook list"""
+        h = selected_layer.register_forward_hook(hook)
+        self.hooks.append(h)
+        return h
+
+    def remove_hook(self) -> None:
+        """Remove all hooks from the model"""
+        for h in self.hooks:
+            h.remove()
+
+
+@check_noop
+def watch(
+    trainer: Trainer, layer: Layer = None, embedding_dim: EmbeddingDim = None
+) -> None:
+    """
+    [`watch`] is used to hook into to the trainer
+    to log to [Galileo](https://www.rungalileo.io/)
+    :param trainer: Trainer object
+    :return: None
+    """
+    # Callback which we add to the trainer
+    dqcallback = DQCallback(layer=layer, embedding_dim=embedding_dim)
+    # The columns needed for the forward process
+    signature_cols = add_id_to_signature_columns(trainer)
+    # We wrap the data collator to remove the id column
+    trainer.data_collator = remove_id_collate_fn_wrapper(
+        trainer.data_collator, signature_cols, dqcallback.helper_data
+    )
+    trainer.add_callback(dqcallback)

--- a/dataquality/loggers/data_logger/text_classification.py
+++ b/dataquality/loggers/data_logger/text_classification.py
@@ -264,10 +264,29 @@ class TextClassificationDataLogger(BaseGalileoDataLogger):
         HuggingFace datasets can be sliced, returning a dict that is in the correct
         format to log directly.
         """
+
+        parse_label = lambda x: x  # noqa: E731
+        # If label is integer, convert to string #
+
+        if isinstance(dataset[0].get(label, None), int):
+            try:
+                parse_label = lambda x: dataset.features[label].int2str(x)  # noqa: E731
+            except Exception:
+                # TODO: Simplify this logic with mapping the int label to string ticket
+                raise GalileoException(
+                    "Your dataset does not have label names. Please include them"
+                )
+
+        assert dataset[0].get(id) is not None, GalileoException(
+            f"id ({id}) field must be present in dataset"
+        )
+
         for i in range(0, len(dataset), batch_size):
             chunk = dataset[i : i + batch_size]
             data = dict(
-                text=chunk[text], id=chunk[id], label=chunk[label] if label else None
+                text=chunk[text],
+                id=chunk[id],
+                label=parse_label(chunk[label]) if label else None,
             )
             chunk_meta = {col: chunk[col] for col in meta}
             self._log_dict(data, chunk_meta, split, inference_name)

--- a/dataquality/utils/transformers.py
+++ b/dataquality/utils/transformers.py
@@ -1,0 +1,70 @@
+import inspect
+from typing import Any, Callable, Dict, List, Union
+
+from transformers import Trainer
+
+
+def remove_id_collate_fn_wrapper(
+    collate_fn: Union[Callable, Any], keep_cols: List[str], store: Dict[str, Any]
+) -> Callable:
+    """Removes the id from each row and pass the cleaned version on.
+
+    Will be used as a wrapper for the collate function.
+    :param collate_fn: The collate function to wrap
+    :param store: The store to use to save the ids (currently passed by reference)
+    :return: The wrapped collate function
+    """
+
+    def remove_id(rows: List[dict]) -> List[dict]:
+        """Removes the id from each row and pass the cleaned version on.
+        :param rows: The rows to clean
+        :return: The cleaned rows
+        """
+        # Remove id by reference
+        ids = []
+        clean_rows = []
+        for row in rows:
+            clean_row = {}
+            for key, value in row.items():
+                if key == "id":
+                    ids.append(value)
+                # Only keep the columns that are not in the signature columns
+                elif key in keep_cols:
+                    clean_row[key] = value
+                # If the signature columns are not set, keep all columns
+                elif len(keep_cols) == 0:
+                    clean_row[key] = value
+            clean_rows.append(clean_row)
+        store["ids"] = ids
+        return collate_fn(clean_rows)
+
+    return remove_id
+
+
+def add_id_to_signature_columns(trainer: Trainer) -> List[str]:
+    """Adds the signature columns to the trainer.
+    Usually the signature columns are label and label_ids.
+    This function will add them if they are not already present.
+    Additionally it will add the id column if it is not present.
+    :param trainer: The trainer to add the id column to.
+    """
+    # Taken from the trainer source code
+    if not trainer.args.remove_unused_columns:
+        return []
+
+    # Taken from the trainer source code
+    if trainer._signature_columns is None:
+        # Inspect model forward signature to keep only the arguments it accepts.
+        signature = inspect.signature(trainer.model.forward)
+        # Labels may be named label or label_ids,
+        # the default data collator handles that.
+        signature_keys = list(signature.parameters.keys()) + ["label", "label_ids"]
+        signature_cols = list(set(signature_keys + trainer.label_names))
+        trainer._signature_columns = signature_cols  # type: ignore
+
+    # Here we add the ids so they won't get removed
+    if isinstance(trainer._signature_columns, list):
+        if "id" not in trainer._signature_columns:
+            trainer._signature_columns.append("id")
+        return trainer._signature_columns
+    return []

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,3 @@
+source .venv/bin/activate
+. ./scripts/set-local-env.sh
+pytest --cov=dataquality --cov=tests --cov=docs_src --cov-report=term-missing --cov-report=xml -o console_output_style=progress --disable-warnings ${@}

--- a/tests/test_text_classification_hf.py
+++ b/tests/test_text_classification_hf.py
@@ -1,0 +1,333 @@
+from typing import Any, Callable, Generator
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+from datasets import load_metric
+from torch.nn import Module
+from torch.utils.data import DataLoader
+from transformers import (
+    AutoModel,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    Trainer,
+    TrainingArguments,
+)
+
+import dataquality as dq
+from dataquality import config
+from dataquality.integrations.transformers_trainer import watch
+from dataquality.schemas.task_type import TaskType
+from tests.utils.hf_datasets_mock import mock_dataset, mock_dataset_repeat
+from tests.utils.mock_request import mocked_create_project_run, mocked_get_project_run
+
+# Load models locally
+try:
+    tokenizer = AutoTokenizer.from_pretrained("tmp/testing-random-distilbert-tokenizer")
+except Exception:
+    tokenizer = AutoTokenizer.from_pretrained(
+        "hf-internal-testing/tiny-random-distilbert"
+    )
+    tokenizer.save_pretrained("tmp/testing-random-distilbert-tokenizer")
+try:
+    model = AutoModelForSequenceClassification.from_pretrained(
+        "tmp/testing-random-distilbert-sq"
+    )
+except Exception:
+    model = AutoModelForSequenceClassification.from_pretrained(
+        "hf-internal-testing/tiny-random-distilbert"
+    )
+    model.save_pretrained("tmp/testing-random-distilbert-sq")
+
+
+metric = load_metric("accuracy")
+
+
+def preprocess_function(examples, tokenizer):
+    return tokenizer(
+        examples["text"], padding="max_length", max_length=201, truncation=True
+    )
+
+
+def compute_metrics(eval_pred):
+    predictions, labels = eval_pred
+    predictions = predictions.argmax(axis=1)
+    return metric.compute(predictions=predictions, references=labels)
+
+
+# 🔭🌕 Galileo logging
+mock_dataset_with_ids = mock_dataset.map(lambda x, idx: {"id": idx}, with_indices=True)
+mock_dataset_with_ids_repeat = mock_dataset_repeat.map(
+    lambda x, idx: {"id": idx}, with_indices=True
+)
+
+encoded_train_dataset = mock_dataset_with_ids.map(
+    lambda x: preprocess_function(x, tokenizer), batched=True
+)
+encoded_test_dataset = mock_dataset_with_ids.map(
+    lambda x: preprocess_function(x, tokenizer), batched=True
+)
+
+encoded_train_dataset_repeat = mock_dataset_with_ids_repeat.map(
+    lambda x: preprocess_function(x, tokenizer), batched=True
+)
+encoded_test_dataset_repeat = mock_dataset_with_ids_repeat.map(
+    lambda x: preprocess_function(x, tokenizer), batched=True
+)
+
+# Training arguments and training part
+metric_name = "accuracy"
+batch_size = 4
+
+args_default = TrainingArguments(
+    output_dir="tmp",
+    evaluation_strategy="epoch",
+    save_strategy="epoch",
+    learning_rate=3e-4,
+    per_device_train_batch_size=batch_size,
+    per_device_eval_batch_size=batch_size,
+    num_train_epochs=1,
+    weight_decay=0.01,
+    load_best_model_at_end=True,
+    metric_for_best_model=metric_name,
+    push_to_hub=False,
+)
+
+
+@patch("requests.post", side_effect=mocked_create_project_run)
+@patch("requests.get", side_effect=mocked_get_project_run)
+@patch.object(dq.core.init.ApiClient, "valid_current_user", return_value=True)
+def test_end_to_end_without_callback(
+    mock_valid_user: MagicMock,
+    mock_requests_get: MagicMock,
+    mock_requests_post: MagicMock,
+    set_test_config: Callable,
+) -> None:
+    """Base case: Training on a dataset"""
+
+    trainer = Trainer(
+        model,
+        args_default,
+        train_dataset=encoded_train_dataset,
+        eval_dataset=encoded_test_dataset,
+        tokenizer=tokenizer,
+        compute_metrics=compute_metrics,
+    )
+
+    trainer.train()
+
+
+@patch.object(dq.core.init.ApiClient, "valid_current_user", return_value=True)
+@patch.object(dq.core.finish, "_version_check")
+@patch.object(dq.core.finish, "_reset_run")
+@patch.object(dq.core.finish, "upload_dq_log_file")
+@patch.object(dq.clients.api.ApiClient, "make_request")
+@patch.object(dq.core.finish, "wait_for_run")
+def test_hf_watch_e2e(
+    mock_wait_for_run: MagicMock,
+    mock_make_request: MagicMock,
+    mock_upload_log_file: MagicMock,
+    mock_reset_run: MagicMock,
+    mock_version_check: MagicMock,
+    mock_valid_user: MagicMock,
+    set_test_config: Callable,
+    cleanup_after_use: Generator,
+) -> None:
+    """Base case: Tests creating a new project and run"""
+    set_test_config(task_type=TaskType.text_classification)
+    # 🔭🌕 Galileo logging
+    dq.set_labels_for_run(mock_dataset.features["label"].names)
+    train_dataset = mock_dataset_with_ids
+    test_dataset = mock_dataset_with_ids
+    dq.log_dataset(train_dataset, split="train")
+    dq.log_dataset(test_dataset, split="test")
+
+    trainer = Trainer(
+        model,
+        args_default,
+        train_dataset=encoded_train_dataset,
+        eval_dataset=encoded_test_dataset,
+        tokenizer=tokenizer,
+        compute_metrics=compute_metrics,
+    )
+    # 🔭🌕 Galileo logging
+    watch(trainer)
+    trainer.train()
+    dq.finish()
+
+
+@patch("requests.post", side_effect=mocked_create_project_run)
+@patch("requests.get", side_effect=mocked_get_project_run)
+@patch.object(dq.core.init.ApiClient, "valid_current_user", return_value=True)
+def test_remove_unused_columns(
+    mock_valid_user: MagicMock,
+    mock_requests_get: MagicMock,
+    mock_requests_post: MagicMock,
+    set_test_config: Callable,
+) -> None:
+    """Base case: Tests watch function to pass"""
+    set_test_config(task_type=TaskType.text_classification)
+
+    train_dataset = mock_dataset_with_ids
+    test_dataset = mock_dataset_with_ids
+    dq.log_dataset(train_dataset, split="train")
+    dq.log_dataset(test_dataset, split="test")
+    dq.set_labels_for_run(mock_dataset.features["label"].names)
+    assert config.current_run_id
+    assert config.current_project_id
+    t_args = TrainingArguments(
+        output_dir="tmp",
+        evaluation_strategy="epoch",
+        save_strategy="epoch",
+        learning_rate=3e-4,
+        per_device_train_batch_size=batch_size,
+        per_device_eval_batch_size=batch_size,
+        num_train_epochs=1,
+        weight_decay=0.01,
+        load_best_model_at_end=True,
+        metric_for_best_model=metric_name,
+        push_to_hub=False,
+        remove_unused_columns=False,
+    )
+    trainer = Trainer(
+        model,
+        t_args,
+        train_dataset=encoded_train_dataset.with_format(
+            "torch", columns=["id", "attention_mask", "input_ids", "label"]
+        ),
+        eval_dataset=encoded_test_dataset.with_format(
+            "torch", columns=["id", "attention_mask", "input_ids", "label"]
+        ),
+        tokenizer=tokenizer,
+        compute_metrics=compute_metrics,
+    )
+
+    assert trainer._signature_columns is None, "Signature columns should be None"
+    watch(trainer)
+    assert trainer._signature_columns is None, "Signature columns should be None"
+
+    trainer.train()
+
+
+@patch("requests.post", side_effect=mocked_create_project_run)
+@patch("requests.get", side_effect=mocked_get_project_run)
+@patch.object(dq.core.init.ApiClient, "valid_current_user", return_value=True)
+def test_ner_error(
+    mock_valid_user: MagicMock,
+    mock_requests_get: MagicMock,
+    mock_requests_post: MagicMock,
+    set_test_config: Callable,
+) -> None:
+    """Base case: Tests fail if task is not text_classification"""
+    set_test_config(task_type=TaskType.text_ner)
+
+    trainer = Trainer(
+        model,
+        args_default,
+        train_dataset=encoded_train_dataset,
+        eval_dataset=encoded_test_dataset,
+        tokenizer=tokenizer,
+        compute_metrics=compute_metrics,
+    )
+    watch(trainer)
+    with pytest.raises(AssertionError) as e:
+        trainer.train()
+    assert "text_classification" in str(
+        e.value
+    ), "Task type should be text_classification"
+
+
+@patch("requests.post", side_effect=mocked_create_project_run)
+@patch("requests.get", side_effect=mocked_get_project_run)
+@patch.object(dq.core.init.ApiClient, "valid_current_user", return_value=True)
+def test_training_run(
+    mock_valid_user: MagicMock,
+    mock_requests_get: MagicMock,
+    mock_requests_post: MagicMock,
+    set_test_config: Callable,
+) -> None:
+    """Base case: Tests watch function to pass"""
+
+    trainer = Trainer(
+        model,
+        args_default,
+        train_dataset=encoded_train_dataset_repeat,
+        eval_dataset=encoded_test_dataset_repeat,
+        tokenizer=tokenizer,
+        compute_metrics=compute_metrics,
+    )
+    trainer.train()
+
+
+def test_embedding_layer_indexing():
+    """Tests that the embedding layer can be indexed with select"""
+    arr = np.array([[[1], [2], [3]], [[4], [5], [6]]])
+    tensor = torch.tensor(arr)
+    arr_sliced = arr[:, 0]
+    arr_sliced.shape
+    tensor_sliced = tensor.select(*(1, 0))
+    assert arr.shape == tensor.shape, "shape must match"
+    assert np.array_equal(arr, tensor.numpy()), "values must match"
+    assert tensor_sliced.shape == arr_sliced.shape, "sliced shape must match"
+    assert np.array_equal(arr_sliced, tensor_sliced.numpy()), "shape must be same"
+
+
+historic_embeddings = None
+
+
+def _embedding_hook(model: Module, model_input: Any, model_output: Any) -> None:
+    """
+    Hook to extract the embeddings from the model
+    :param model: Model pytorch model
+    :param model_input: Model input
+    :param model_output: Model output
+    :return: None
+    """
+    global historic_embeddings
+    if hasattr(model_output, "last_hidden_state"):
+        output_detached = model_output.last_hidden_state.detach()
+        if historic_embeddings is None:
+            historic_embeddings = output_detached
+
+
+@patch.object(dq.core.init.ApiClient, "valid_current_user", return_value=True)
+@patch.object(dq.core.finish, "_version_check")
+@patch.object(dq.core.finish, "_reset_run")
+@patch.object(dq.core.finish, "upload_dq_log_file")
+@patch.object(dq.clients.api.ApiClient, "make_request")
+@patch.object(dq.core.finish, "wait_for_run")
+def test_forward_hook(
+    mock_wait_for_run: MagicMock,
+    mock_make_request: MagicMock,
+    mock_upload_log_file: MagicMock,
+    mock_reset_run: MagicMock,
+    mock_version_check: MagicMock,
+    mock_valid_user: MagicMock,
+    set_test_config: Callable,
+    cleanup_after_use: Generator,
+) -> None:
+    """Tests that the embedding layer is correctly logged"""
+    model_seq = AutoModelForSequenceClassification.from_pretrained(
+        "hf-internal-testing/tiny-random-distilbert"
+    )
+    model_base = AutoModel.from_pretrained("hf-internal-testing/tiny-random-distilbert")
+
+    train_sample = mock_dataset_with_ids_repeat.map(
+        lambda x: preprocess_function(x, tokenizer), batched=True
+    ).with_format("torch", columns=["attention_mask", "input_ids", "id"])
+
+    dataloader = DataLoader(
+        train_sample,
+        batch_size=4,
+    )
+    for batch in dataloader:
+        batch.pop("id").detach().numpy()
+        pred = model_base(**batch)
+        next(model_seq.children()).register_forward_hook(_embedding_hook)
+        model_seq(**batch)
+        embeddings = pred[0][:, 0].detach().numpy()[0]
+        embeddings_cls = historic_embeddings[:, 0].detach().numpy()[0]
+        break
+
+    assert np.array_equal(embeddings, embeddings_cls), "Embeddings must be same"

--- a/tests/utils/hf_datasets_mock.py
+++ b/tests/utils/hf_datasets_mock.py
@@ -1,0 +1,67 @@
+from datasets import ClassLabel, Dataset, Features, Value
+
+features = Features(
+    {
+        "text": Value(dtype="string", id=None),
+        "label": ClassLabel(num_classes=2, names=["neg", "pos"]),
+    }
+)
+
+mock_dataset = Dataset.from_dict(
+    {
+        "text": [
+            "i didnt feel humiliated",
+            "i can go from feeling so hopeless to so damned ",
+            "im grabbing a minute to post i feel greedy wrong",
+            "i am ever feeling nostalgic about the fireplace ",
+            "i am feeling grouchy",
+            "ive been feeling a little burdened lately wasnt sure why that was",
+            "ive been taking or milligrams or times recommended",
+            "i feel as confused about life as a teenager",
+            "i have been with petronas for years i feel that petronas",
+            "i feel romantic too",
+            "i feel like i have to make the suffering i m seeing mean something",
+            "i do feel that running is a divine experience",
+            "i think it s the easiest time of year to feel dissatisfied",
+            "i feel low energy i m just thirsty",
+            "i have immense sympathy with the general point but as a possible",
+            "i do not feel reassured anxiety is on each side",
+            "i didnt really feel that embarrassed",
+            "i feel pretty pathetic most of the time",
+            "i started feeling sentimental about dolls",
+            "i now feel compromised and skeptical",
+        ],
+        "label": [0, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1],
+    },
+    features,
+)
+
+
+mock_dataset_repeat = Dataset.from_dict(
+    {
+        "text": [
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+            "i didnt feel humiliated",
+        ],
+        "label": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    },
+    features,
+)


### PR DESCRIPTION
* [x] I have added tests to `tests` to cover my changes.
* [x] I have updated `docs/`, if necessary.
* [x] I have updated the `README.md`, if necessary.

***What existing issue does this pull request close?***

closes #402

***How are these changes tested?***

We load the smallest testing model and have an end to end test.
We test for criteria that is necessary during the training:
- Embedding reproducible
- Model finds layer

***Explanation***

For automatic training HF needs a model and a tokenizer.
The model can be chosen for text classfication. This will add aditional layers ontop of a pretrained model.

PyTorch provides hooks, you can use these hooks to hook into a model.
We hook into the last_hidden_state (embeddings) of the model and the classifier output (logits)
To add the ids, we hook into the dataloader.

Finally we have a workaround so we dont need to add the forward(x,y, *id*) function.
We use the data collator. We then infer the signature columns from the model and we add the id column.
Finally we wrap the collator around the trainer collator.

So each time we get a new batch we save the ids, once the training step is complete we log the embeddings.

Workflow in the Trainer API:

1. init trainer
2. save dataloader
3. save colate function
4. during training begin: get signature columns (input_ids, attention_mask, label)
5. create dataloader with collate function.


Our process:
1. init trainer
2. save dataloader
3. save colate function
4. *we override the saved colate function after init*
5. *we override the signature columns after init and add id*
6. during training begin: get signature columns (input_ids, attention_mask, label)
7.  create dataloader with collate function.

Implementation is now easy as 1...2...3

```
# 🔭🌕 Galileo logging
# add ids
ds = ds.map(lambda x,idx : {"id":idx},with_indices=True)
dq.log_dataset(ds["train"], split="train")
dq.log_dataset(ds["test"], split="validation")
dq.set_labels_for_run(train_dataset.features['label'].names)


args = TrainingArguments(...)
trainer = Trainer(...)
watch(trainer) # 🔭🌕 Galileo logging
trainer.train()
dq.finish() # 🔭🌕 Galileo logging
```