### PR TITLE
vaex is silly sometimes

### DIFF
--- a/dataquality/loggers/data_logger/text_classification.py
+++ b/dataquality/loggers/data_logger/text_classification.py
@@ -346,7 +346,7 @@ class TextClassificationDataLogger(BaseGalileoDataLogger):
         self.texts = df["text"].tolist()
         self.ids = df["id"].tolist()
         # Inference case
-        if "label" in df.columns:
+        if "label" in df:
             self.labels = df["label"].tolist()
         for meta_col in meta:
             self.meta[str(meta_col)] = df[meta_col].tolist()


### PR DESCRIPTION
`"col" in df` works for pandas and vaex, but `col in df.columns` does not work for vaex if the column is virtual

![image](https://user-images.githubusercontent.com/22605641/195717488-313a2898-4870-402c-b7bb-fc9264c15d2f.png)
