### PR TITLE
dont use env var, might not be there

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -1,6 +1,6 @@
 "dataquality"
 
-__version__ = "v0.7.0"
+__version__ = "v0.7.1"
 
 import os
 import resource

--- a/dataquality/core/_config.py
+++ b/dataquality/core/_config.py
@@ -113,7 +113,7 @@ def _check_dq_version() -> None:
     """Check that user is running valid version of DQ client
     Pings backend to check minimum DQ version requirements.
     """
-    r = requests.get(f"{os.environ[GalileoConfigVars.API_URL]}/{Route.healthcheck}/dq")
+    r = requests.get(f"{config.api_url}/{Route.healthcheck}/dq")
     if not r.ok:
         if r.status_code == 404:
             # We don't want to raise error if api doesn't have dq healthcheck yet


### PR DESCRIPTION
if a user imports dataquality, we will read they environment from the `config.json` in that case, the `API_URL` env var wont be set

so you get 
<img width="1051" alt="image" src="https://user-images.githubusercontent.com/22605641/198702865-6bf49616-d8e7-4309-a71d-598a927078ad.png">
