### PR TITLE
Use training not train and test not testing

### DIFF
--- a/dataquality/integrations/keras.py
+++ b/dataquality/integrations/keras.py
@@ -96,7 +96,7 @@ class DataQualityCallback(keras.callbacks.Callback):
 
     def on_train_batch_begin(self, batch: Any, logs: Dict = None) -> None:
         self._clear_logger_config_helper_data()
-        dq.set_split(Split.train)
+        dq.set_split(Split.training)
 
     def on_train_batch_end(self, batch: Any, logs: Dict = None) -> None:
         dq.log_model_outputs(**self.helper_data)

--- a/dataquality/loggers/model_logger/text_classification.py
+++ b/dataquality/loggers/model_logger/text_classification.py
@@ -61,7 +61,7 @@ class TextClassificationModelLogger(BaseGalileoModelLogger):
     .. code-block:: python
 
         dq.set_epoch(0)
-        dq.set_split("train")
+        dq.set_split("training")
 
         embs: np.ndarray = np.random.rand(4, 768)  # 4 samples, embedding dim 768
         logits: np.ndarray = np.random.rand(4, 3)  # 4 samples, 3 classes
@@ -153,8 +153,6 @@ class TextClassificationModelLogger(BaseGalileoModelLogger):
             f"length, but got (emb, probs, ids) -> ({embs_len},{probs_len}, {ids_len})"
         )
 
-        # User may manually pass in 'train' instead of 'training' / 'test' vs 'testing'
-        # but we want it to conform
         try:
             self.split = Split[self.split].value
         except KeyError:

--- a/dataquality/loggers/model_logger/text_multi_label.py
+++ b/dataquality/loggers/model_logger/text_multi_label.py
@@ -38,7 +38,7 @@ class TextMultiLabelModelLogger(TextClassificationModelLogger):
     .. code-block:: python
 
         dq.set_epoch(0)
-        dq.set_split("train")
+        dq.set_split("training")
 
         # 3 samples, embedding dim 768. Only 1 embedding vector can be logged for all
         # tasks. Each task CANNOT have it's own embedding vector

--- a/dataquality/schemas/split.py
+++ b/dataquality/schemas/split.py
@@ -6,10 +6,8 @@ from dataquality.exceptions import GalileoException
 
 class Split(str, Enum):
     training = "training"
-    train = "training"
     validation = "validation"
     test = "test"
-    testing = "test"
     inference = "inference"
 
     @staticmethod
@@ -24,6 +22,8 @@ def conform_split(split: Union[str, Split]) -> Split:
     """
     if isinstance(split, Split):
         return split
+    if split == "train":  # Needed since HF datasets uses "train"
+        return Split.training
     try:
         return Split[split]
     except KeyError:

--- a/tests/integration/mock_training_run.py
+++ b/tests/integration/mock_training_run.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         texts=train_dataset["text"],
         labels=train_dataset["label"],
         ids=train_dataset["id"],
-        split="train",
+        split="training",
     )
     dataquality.log_data_samples(
         texts=test_dataset["text"],
@@ -95,7 +95,7 @@ if __name__ == "__main__":
             dataquality.log_model_outputs(
                 emb=embedding,
                 probs=probs,
-                split="train",
+                split="training",
                 epoch=epoch_idx,
                 ids=batch["id"],
             )

--- a/tests/test_autolog.py
+++ b/tests/test_autolog.py
@@ -78,7 +78,7 @@ def test_torch_autolog(cleanup_after_use: Callable, set_test_config: Callable) -
             _ = torch_model(x, attention_mask, x_idxs=x_idxs)
 
         with torch.no_grad():
-            dataquality.set_split(Split.testing)
+            dataquality.set_split(Split.test)
             for data in test_dataloader:
                 x_idxs, x, attention_mask, y = data
 

--- a/tests/test_multi_label.py
+++ b/tests/test_multi_label.py
@@ -129,7 +129,7 @@ def test_log_dataset(
     with mock.patch("dataquality.core.log.get_data_logger") as mock_method:
         mock_method.return_value = logger
         dq.log_dataset(
-            dataset, text="my_text", label="my_labels", id="my_id", split="train"
+            dataset, text="my_text", label="my_labels", id="my_id", split="training"
         )
 
         assert logger.texts == ["sample1", "sample2", "sample3"]
@@ -152,7 +152,7 @@ def test_log_dataset_tuple(
 
     with mock.patch("dataquality.core.log.get_data_logger") as mock_method:
         mock_method.return_value = logger
-        dq.log_dataset(dataset, text=0, label=1, id=2, split="train")
+        dq.log_dataset(dataset, text=0, label=1, id=2, split="training")
 
         assert logger.texts == ["sample1", "sample2", "sample3"]
         log_labels = [list(i) for i in logger.labels]
@@ -302,12 +302,12 @@ def test_logged_labels_dont_match_set_labels(
     if set_labels_first:
         dataquality.set_labels_for_run(labels)
         with pytest.raises(AssertionError) as e:
-            dataquality.log_dataset(dataset, split="train")
+            dataquality.log_dataset(dataset, split="training")
         assert str(e.value).startswith(
             "The input labels you log must be exactly the same"
         )
     else:
-        dataquality.log_dataset(dataset, split="train")
+        dataquality.log_dataset(dataset, split="training")
         dataquality.get_data_logger().logger_config.observed_num_labels = [2, 2, 2]
         dataquality.set_labels_for_run(labels)
         with pytest.raises(AssertionError) as e:

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -679,7 +679,7 @@ def test_log_dataset(
             gold_spans="my_spans",
             id="my_id",
             text_token_indices="text_tokens",
-            split="train",
+            split="training",
         )
 
         assert logger.texts == TEXT_INPUTS
@@ -710,7 +710,7 @@ def test_log_dataset_tuple(
         mock_method.return_value = logger
 
         dataquality.log_dataset(
-            dataset, text=0, gold_spans=1, id=2, text_token_indices=3, split="train"
+            dataset, text=0, gold_spans=1, id=2, text_token_indices=3, split="training"
         )
 
         assert logger.texts == TEXT_INPUTS

--- a/tests/test_text_classification.py
+++ b/tests/test_text_classification.py
@@ -129,7 +129,7 @@ def test_log_dataset(
     with mock.patch("dataquality.core.log.get_data_logger") as mock_method:
         mock_method.return_value = logger
         dq.log_dataset(
-            dataset, text="my_text", label="my_labels", id="my_id", split="train"
+            dataset, text="my_text", label="my_labels", id="my_id", split="training"
         )
 
         assert logger.texts == ["sample1", "sample2", "sample3"]
@@ -162,7 +162,7 @@ def test_log_dataset_tuple(
 
     with mock.patch("dataquality.core.log.get_data_logger") as mock_method:
         mock_method.return_value = logger
-        dq.log_dataset(dataset, text=0, label=1, id=2, split="train")
+        dq.log_dataset(dataset, text=0, label=1, id=2, split="training")
 
         assert logger.texts == ["sample1", "sample2", "sample3"]
         assert logger.labels == ["A", "A", "B"]
@@ -187,7 +187,7 @@ def test_log_dataset_default(
     logger = TextClassificationDataLogger()
     with mock.patch("dataquality.core.log.get_data_logger") as mock_method:
         mock_method.return_value = logger
-        dq.log_dataset(dataset, split="train")
+        dq.log_dataset(dataset, split="training")
 
         assert logger.texts == ["sample1", "sample2", "sample3"]
         assert logger.labels == ["A", "A", "B"]
@@ -212,7 +212,7 @@ def test_output_no_input_for_split(
 
     When you try to upload data for a split that has no input data
     """
-    dq.log_dataset(dataset, split="train")
+    dq.log_dataset(dataset, split="training")
     dq.log_model_outputs(
         embs=np.random.rand(3, 50),
         logits=np.random.rand(3, 10),
@@ -240,9 +240,9 @@ def test_logged_labels_dont_match_set_labels(
     if set_labels_first:
         dataquality.set_labels_for_run(labels)
         with pytest.raises(AssertionError) as e:
-            dataquality.log_dataset(dataset, split="train")
+            dataquality.log_dataset(dataset, split="training")
     else:
-        dataquality.log_dataset(dataset, split="train")
+        dataquality.log_dataset(dataset, split="training")
         dataquality.get_data_logger().logger_config.observed_num_labels = len(labels)
         dataquality.set_labels_for_run(labels)
         with pytest.raises(AssertionError) as e:
@@ -262,7 +262,7 @@ def test_log_int_labels(set_test_config: Callable, cleanup_after_use: Callable) 
             {"text": "sample3", "label": 2, "id": 3},
         ]
     )
-    dataquality.log_dataset(dataset, split="train")
+    dataquality.log_dataset(dataset, split="training")
     dataquality.get_data_logger().logger_config.observed_num_labels = len(labels)
 
     dataquality.set_labels_for_run(labels)

--- a/tests/test_text_classification_hf.py
+++ b/tests/test_text_classification_hf.py
@@ -140,7 +140,7 @@ def test_hf_watch_e2e(
     dq.set_labels_for_run(mock_dataset.features["label"].names)
     train_dataset = mock_dataset_with_ids
     test_dataset = mock_dataset_with_ids
-    dq.log_dataset(train_dataset, split="train")
+    dq.log_dataset(train_dataset, split="training")
     dq.log_dataset(test_dataset, split="test")
 
     trainer = Trainer(
@@ -171,7 +171,7 @@ def test_remove_unused_columns(
 
     train_dataset = mock_dataset_with_ids
     test_dataset = mock_dataset_with_ids
-    dq.log_dataset(train_dataset, split="train")
+    dq.log_dataset(train_dataset, split="training")
     dq.log_dataset(test_dataset, split="test")
     dq.set_labels_for_run(mock_dataset.features["label"].names)
     assert config.current_run_id


### PR DESCRIPTION
Remove deprecated `Split.train` and `Split.testing`