### PR TITLE
Small tokenizer fixes

### DIFF
--- a/dataquality/integrations/hf.py
+++ b/dataquality/integrations/hf.py
@@ -181,7 +181,6 @@ def tokenize_and_log_dataset(
     )
     dd_keys = tokenized_datasets.keys()
     for ds_key in dd_keys:
-        inference_name = ""
         kwargs = {}
         dataset: Dataset = tokenized_datasets[ds_key]
         # We assume the key is inference name if it is not a valid split

--- a/dataquality/utils/hf_tokenizer.py
+++ b/dataquality/utils/hf_tokenizer.py
@@ -74,17 +74,18 @@ class LabelTokenizer:
     def initialize_sample(self, k: int) -> None:
         self.previous_word_id = -1
         self.word_ids = self.tokenized_samples.word_ids(batch_index=k)
-        # If ner_tags is not present, we know split must be 'inference'
-        # See hf.py `_validate_dataset` for more details
-        if HFCol.ner_tags not in self.ds.features:
-            self.word_gold_spans = []
-        else:
+        # We check ds and ds.features to accomodate HF and arrow datasets
+        if HFCol.ner_tags in self.ds or HFCol.ner_tags in self.ds.features:
             existing_labels = [
                 self.idx_2_labels[label] for label in self.ds[HFCol.ner_tags][k]
             ]
             self.word_gold_spans = extract_gold_spans_at_word_level(
                 existing_labels, self.schema
             )
+        # If ner_tags is not present, we know split must be 'inference'
+        # See hf.py `_validate_dataset` for more details
+        else:
+            self.word_gold_spans = []
         self.original_word_idx = -1
         self.char_seen = -len(self.ds[HFCol.tokens][k][0])
         self.adjusted_label_indices = [self.labels_2_idx["O"]] * len(self.word_ids)


### PR DESCRIPTION
- Remove unneeded `inference_name`
- Accomodate for arrow and HF datasets 