### PR TITLE
fix metrics caching

### DIFF
--- a/dataquality/clients/api.py
+++ b/dataquality/clients/api.py
@@ -1,4 +1,6 @@
+import json
 import os
+from json import JSONDecodeError
 from time import sleep
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -536,10 +538,14 @@ class ApiClient:
                 print(f"Done! Job finished with status {job.get('status')}")
                 return
             elif job.get("status") == "failed":
+                # Try to properly format the stacktrace
+                try:
+                    err = json.loads(job.get("error_message", ""))
+                except JSONDecodeError:
+                    err = job.get("error_message")
                 raise GalileoException(
-                    f"It seems your run failed with status "
-                    f"{job.get('status')}, error {job.get('error_message')}"
-                )
+                    f"It seems your run failed with error\n{err}"
+                ) from None
             elif not job or job.get("status") in ["unstarted", "in_progress"]:
                 sleep(2)
             else:

--- a/dataquality/metrics.py
+++ b/dataquality/metrics.py
@@ -477,7 +477,9 @@ def _process_exported_dataframe(
                 "Embeddings are not available in HF format, ignoring", GalileoWarning
             )
         else:
-            emb_df = get_data_embeddings(project_name, run_name, split, inference_name)
+            emb_df = get_data_embeddings(
+                project_name, run_name, split, inference_name
+            ).copy()
             emb_df.rename("emb", "data_emb")
             data_df = data_df.join(emb_df, on="id")
     if include_probs:


### PR DESCRIPTION
two small changes here

Updated metrics to `.copy` the dataframe so not to affect the cache.

Before, you see that the column name of `emb` is changed to `data_emb` depending on the context. When you call `get_dataframe(include_data_embs=True)` we rename `emb` to `data_emb` to be clear. But if you just call `get_data_embeddings` it makes sense to call that column `emb` because it's the only embeddings. But when we make call one then the other, the cache dataframe is modified (since we don't call copy) 

Before you see the second call to `get_data_embeddings` has the wrong column name 
![image](https://user-images.githubusercontent.com/22605641/203869326-4b942e89-32b3-4744-86b4-fc7258ac10b7.png)

After, it's fixed
![image](https://user-images.githubusercontent.com/22605641/203869356-703c7739-17e9-4ca3-81bf-87e871b86632.png)


Another small change is just the way we format the exception on `wait_for_run` in the case of an exception. Currently it's not well formed, but I did some messing around and got it formed by keeping the exception on 1 line and `json.loads`ing it
before
![image](https://user-images.githubusercontent.com/22605641/203869420-e7c40296-cec1-43fb-b72c-2e304377f6ae.png)

after
![image](https://user-images.githubusercontent.com/22605641/203869447-490f88c7-5179-4a5c-ab50-7fb8198ed43c.png)
