### PR TITLE
save the ner labels as well

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -1,6 +1,6 @@
 "dataquality"
 
-__version__ = "v0.8.4"
+__version__ = "v0.8.5"
 
 import os
 

--- a/dataquality/core/finish.py
+++ b/dataquality/core/finish.py
@@ -61,6 +61,7 @@ def finish(
         labels=data_logger.logger_config.labels,
         task_type=config.task_type.value,
         tasks=data_logger.logger_config.tasks,
+        ner_labels=data_logger.logger_config.ner_labels,
     )
     if data_logger.logger_config.inference_logged:
         body.update(

--- a/dataquality/loggers/data_logger/text_ner.py
+++ b/dataquality/loggers/data_logger/text_ner.py
@@ -701,8 +701,20 @@ class TextNERDataLogger(BaseGalileoDataLogger):
 
     @classmethod
     def validate_labels(cls) -> None:
-        """Validates and cleans labels, see _clean_labels"""
-        cls.logger_config.labels = cls._clean_labels()
+        """Validates and cleans labels, see _clean_labels and saves ner_labels
+
+        ner_labels are all of the labels that start with a tag (B-, I-, E- etc) as well
+        as the O tag
+        """
+        # We run this first because _clean_labels does the necessary validation
+        clean_labels = cls._clean_labels()
+        ner_labels = [
+            lbl
+            for lbl in cls.logger_config.labels
+            if cls.is_valid_span_label(lbl) or lbl == "O"
+        ]
+        cls.logger_config.labels = clean_labels
+        cls.logger_config.ner_labels = ner_labels
 
     @classmethod
     def _clean_labels(cls) -> List[str]:

--- a/dataquality/loggers/logger_config/base_logger_config.py
+++ b/dataquality/loggers/logger_config/base_logger_config.py
@@ -29,6 +29,7 @@ class BaseLoggerConfig(BaseModel):
     idx_to_id_map: DefaultDict[str, List] = defaultdict(list)
     conditions: List[Condition] = []
     report_emails: List[str] = []
+    ner_labels: List[str] = []
 
     class Config:
         validate_assignment = True


### PR DESCRIPTION
labels = `["PER", "ORG", "LOC"]`

ner_labels = `["O", "B-PER", "I-PER",  "B-ORG", "I-ORG", "B-LOC", "I-LOC"]`

we need those in the exact order provided by the user for the loss probs and conf probs for ner processing likely mislabeled


relates to https://github.com/rungalileo/rungalileo/pull/387