### PR TITLE
deprecate configure function

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -70,11 +70,9 @@ def configure(do_login: bool = True) -> None:
     * GALILEO_USERNAME
     * GALILEO_PASSWORD
     """
-    print("HI-")
     a.log_function("dq/configure")
     warnings.warn(
-        "configure is deprecated, use dq.set_console_url and dq.login",
-        GalileoWarning
+        "configure is deprecated, use dq.set_console_url and dq.login", GalileoWarning
     )
 
     if "GALILEO_API_URL" in os.environ:

--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -1,8 +1,9 @@
 "dataquality"
 
-__version__ = "v0.8.12"
+__version__ = "v0.8.13"
 
 import os
+import warnings
 
 import dataquality.core._config
 import dataquality.integrations
@@ -10,6 +11,8 @@ import dataquality.integrations
 # We try/catch this in case the user installed dq inside of jupyter. You need to
 # restart the kernel after the install and we want to make that clear. This is because
 # of vaex: https://github.com/vaexio/vaex/pull/2226
+from dataquality.exceptions import GalileoWarning
+
 try:
     import dataquality.metrics
     from dataquality.analytics import Analytics
@@ -67,7 +70,12 @@ def configure(do_login: bool = True) -> None:
     * GALILEO_USERNAME
     * GALILEO_PASSWORD
     """
+    print("HI-")
     a.log_function("dq/configure")
+    warnings.warn(
+        "configure is deprecated, use dq.set_console_url and dq.login",
+        GalileoWarning
+    )
 
     if "GALILEO_API_URL" in os.environ:
         del os.environ["GALILEO_API_URL"]


### PR DESCRIPTION
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/22605641/212423598-436a7d63-0f30-4b07-8ce4-b3a8acf36faf.png">



# Why did you use a GalileoWarning and not a DeprecationWarning? 

because for some reason the deprecation warning wouldn't show up in jupyter :/