### PR TITLE
Speed up base64 encoding step for CV data logging

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -1,6 +1,6 @@
 "dataquality"
 
-__version__ = "v0.8.13"
+__version__ = "v0.8.14"
 
 import os
 import warnings

--- a/dataquality/loggers/data_logger/image_classification.py
+++ b/dataquality/loggers/data_logger/image_classification.py
@@ -2,7 +2,6 @@ import os
 from typing import List, Optional, Union
 
 import pandas as pd
-from PIL import Image
 
 from dataquality.loggers.data_logger.base_data_logger import ITER_CHUNK_SIZE, MetasType
 from dataquality.loggers.data_logger.text_classification import (
@@ -13,7 +12,7 @@ from dataquality.loggers.logger_config.image_classification import (
     image_classification_logger_config,
 )
 from dataquality.schemas.split import Split
-from dataquality.utils.cv import _img_to_b64_str
+from dataquality.utils.cv import _img_path_to_b64_str
 
 
 class ImageClassificationDataLogger(TextClassificationDataLogger):
@@ -51,7 +50,7 @@ class ImageClassificationDataLogger(TextClassificationDataLogger):
         meta: Optional[List[Union[str, int]]] = None,
     ) -> None:
         dataset["text"] = dataset[imgs_location_colname].apply(
-            lambda x: _img_to_b64_str(img=Image.open(os.path.join(imgs_dir, x)))
+            lambda x: _img_path_to_b64_str(img_path=os.path.join(imgs_dir, x))
         )
         self.log_dataset(
             dataset=dataset,

--- a/dataquality/utils/cv.py
+++ b/dataquality/utils/cv.py
@@ -1,4 +1,5 @@
 import base64
+import mimetypes
 from io import BytesIO
 
 from PIL import Image
@@ -24,3 +25,18 @@ def _img_to_b64_str(img: Image) -> str:
     prefix = _b64_image_data_prefix(mimetype=img.get_format_mimetype())
     data = _img_to_b64(img=img)
     return (prefix + data).decode("utf-8")
+
+
+def _bytes_to_b64_str(img_bytes: bytes, img_path: str) -> str:
+    mimetype, _ = mimetypes.guess_type(img_path)
+    if mimetype is None:
+        # slow path - load image and read mimetype
+        mimetype = _bytes_to_img(img_bytes).get_format_mimetype()
+    prefix = _b64_image_data_prefix(mimetype=mimetype)
+    b64_data = base64.b64encode(img_bytes)
+    return (prefix + b64_data).decode("utf-8")
+
+
+def _img_path_to_b64_str(img_path: str) -> str:
+    with open(img_path, "rb") as f:
+        return _bytes_to_b64_str(img_bytes=f.read(), img_path=img_path)

--- a/tests/loggers/test_image_classification.py
+++ b/tests/loggers/test_image_classification.py
@@ -127,6 +127,7 @@ def test_base64_image_logging(set_test_config, cleanup_after_use) -> None:
     """
     set_test_config(task_type="image_classification")
 
+    # TODO: move synthetic image dataset creation code into a utility in test_utils
     def make_img(w, h):
         a = np.random.randint(256, size=(w, h, 3), dtype=np.uint8)
         return Image.fromarray(a)

--- a/tests/loggers/test_image_classification.py
+++ b/tests/loggers/test_image_classification.py
@@ -123,7 +123,8 @@ def test_duplicate_ids_augmented(set_test_config, cleanup_after_use) -> None:
 
 def test_base64_image_logging(set_test_config, cleanup_after_use) -> None:
     """
-    Tests that dq.log_image_dataset logs base64-encoded image data when passed image file paths.
+    Tests that dq.log_image_dataset logs base64-encoded image data when passed image
+    file paths.
     """
     set_test_config(task_type="image_classification")
 

--- a/tests/loggers/test_image_classification.py
+++ b/tests/loggers/test_image_classification.py
@@ -1,9 +1,9 @@
+import base64
 import os.path
+from io import BytesIO
+from tempfile import TemporaryDirectory
 from unittest import mock
 from unittest.mock import MagicMock
-from tempfile import TemporaryDirectory
-from io import BytesIO
-import base64
 
 import numpy as np
 import pandas as pd
@@ -138,7 +138,7 @@ def test_base64_image_logging(set_test_config, cleanup_after_use) -> None:
         image_paths = []
         labels = []
         ids = []
-        for i, xtn in enumerate(['.jpg', '.png', '.jpeg', '.gif']):
+        for i, xtn in enumerate([".jpg", ".png", ".jpeg", ".gif"]):
             image_filename = f"{i:03d}.{xtn}"
             image_path = os.path.join(imgs_dir, image_filename)
             image = make_img(32, 32)
@@ -153,7 +153,11 @@ def test_base64_image_logging(set_test_config, cleanup_after_use) -> None:
 
         # log dataset
         dataset = pd.DataFrame(
-            dict(id=ids, label=labels, path=image_paths, )
+            dict(
+                id=ids,
+                label=labels,
+                path=image_paths,
+            )
         )
         dq.set_labels_for_run(["A", "B"])
         dq.log_image_dataset(

--- a/tests/loggers/test_image_classification.py
+++ b/tests/loggers/test_image_classification.py
@@ -1,14 +1,67 @@
+import os.path
 from unittest import mock
 from unittest.mock import MagicMock
+from tempfile import TemporaryDirectory
+from io import BytesIO
+import base64
 
 import numpy as np
+import pandas as pd
 import vaex
+from PIL import Image
 
 import dataquality
 import dataquality as dq
 from dataquality.utils.thread_pool import ThreadPoolManager
 from dataquality.utils.vaex import validate_unique_ids
 from tests.conftest import LOCATION
+
+
+def test_base64(set_test_config, cleanup_after_use) -> None:
+    """
+    TODO
+    """
+    set_test_config(task_type="image_classification")
+
+    def make_img(w, h):
+        a = np.random.randint(256, size=(w, h, 3), dtype=np.uint8)
+        return Image.fromarray(a)
+
+    with TemporaryDirectory() as imgs_dir:
+        images = []
+        image_paths = []
+        labels = []
+        ids = []
+        for i, xtn in enumerate(['.jpg', '.png', '.jpeg', '.gif']):
+            image_path = os.path.join(imgs_dir, f"{i:.03d}.{xtn}")
+            image = make_img(32, 32).save(image_path)
+
+            images.append(image)
+            image_paths.append(image_path)
+            labels.append("A" if i % 2 == 0 else "B")
+            ids.append(i)
+
+        dataset = pd.DataFrame(
+            dict(id=ids, label=labels, path=image_paths,)
+        )
+
+        dq.set_labels_for_run(["A", "B"])
+        dq.log_image_dataset(
+            dataset=dataset,
+            label="label",
+            imgs_location_colname="path"
+        )
+        ThreadPoolManager.wait_for_threads()
+        df = vaex.open(f"{LOCATION}/input_data/training/data_0.arrow")
+
+        base64_images = df["text"]
+        assert len(base64_images) == len(images)
+
+        for image, base64_image in zip(images, base64_images):
+            _, _, content = base64_image.partition("base64,")
+            assert len(content) > 0
+            decoded = Image.open(BytesIO(base64.b64decode(content)))
+            assert np.allclose(np.array(image), np.array(decoded))
 
 
 def test_duplicate_ids_augmented_loop_thread(


### PR DESCRIPTION
* [x] I have added tests to `tests` to cover my changes.
* [ ] I have updated `docs/`, if necessary.
* [ ] I have updated the `README.md`, if necessary.

When an image dataset is logged to Galileo, we convert the image data into a base64 encoded string.  Currently, what we do is

1. Load an image path into a PIL `Image`
2. Get the MIME type from the `Image`
3. Get bytes from the image by calling `Image.save`, using the same image format 
4. Combine the bytes and the MIME type and UTF-8 encode them to a string

This is wasteful, because we already have bytes on disk -- that is what we load in step 1.  If the image is lossy-compressed like JPEG, we may end up double-compressing it in step 3.  And we're run a JPEG decoder (step 1) and possibly encoder (step 3) when we don't need to.

Here I replace the above with

1. Load the image path to bytes
2. Infer the MIME type from the path using python stdlib's `mimetypes`. (If it can't infer a MIME type, fall back to using PIL `Image` as above)
4. Combine the bytes and the MIME type and UTF-8 encode them to a string

Speed comparison on 512x512 images from food-101 dataset:

- main branch: 89.15it/s
- this code: 5416.25it/s

***How are these changes tested?***

I tested this manually in a notebook by running

```bash
pip install 'dataquality @ git+https://github.com/rungalileo/dataquality@feature/base64-speedup'
```

and then logging a small dataset.  The finished run is [here](https://console.dev.rungalileo.io/insights?dataframeColumns=confidence%3B%26data_error_potential%3B%26gold%3B%26level_0%3B%26path%3B%26pred%3B%26text&projectId=b4f8d2d1-a847-4541-8975-7cbe71eac7e8&runId=8256fecd-a307-4931-96a7-852cc8c99bb2&taskType=3)

Doesn't look like there are any automated tests for this code path.  EDIT: added one as `test_base64_image_logging`
