### PR TITLE
Upgrade datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires = [
     "cachetools==5.2.0",
     "importlib-metadata==4.12.0",
     "evaluate",
-    "datasets==2.6.2",
+    "datasets>=2.6",
     "transformers<4.25.0",
     "seqeval",
     "sentence-transformers>=2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires = [
     "cachetools==5.2.0",
     "importlib-metadata==4.12.0",
     "evaluate",
-    "datasets==2.6.1",
+    "datasets==2.6.2",
     "transformers<4.25.0",
     "seqeval",
     "sentence-transformers>=2.2",


### PR DESCRIPTION
Upgrades HF datasets dependency ~~to 2.6.2~~ (update: unpinned) to prevent the error

```python
TypeError: can only concatenate str (not "int") to str
```

that we've been seeing when trying to load some datasets.  See https://github.com/huggingface/datasets/issues/5406


***How are these changes tested?***

Verified that `load_dataset('mnist')` works on 2.6.2, but not on 2.6.1.