### PR TITLE
Fix batched NER data logging

### DIFF
--- a/dataquality/loggers/data_logger/text_ner.py
+++ b/dataquality/loggers/data_logger/text_ner.py
@@ -465,6 +465,8 @@ class TextNERDataLogger(BaseGalileoDataLogger):
                 f"({gold_span_len},{text_len},{text_tokenized_len})"
             )
 
+        self.text_token_indices_flat = []
+
         for sample_id, sample_spans, sample_indices, sample_text in zip(
             self.ids,
             self.gold_spans or [None] * id_len,  # type: ignore


### PR DESCRIPTION
* [ ] I have added tests to `tests` to cover my changes.
* [ ] I have updated `docs/`, if necessary.
* [ ] I have updated the `README.md`, if necessary.

If you try to log a NER dataset with > 100k rows, and don't specify a custom logging batch size, you will currently get an error like

```
ValueError: First columns has length 50000, while column text_token_indices has length 150000
```

This happens because

- The default batch size is 100,000, so we are logging in multiple batches (2 of them)
- On the start of each batch, attributes like `self.texts` of `TextNERDataLogger` [get reset to the batch contents](https://github.com/rungalileo/dataquality/blob/main/dataquality/loggers/data_logger/text_ner.py#L191-L197).
- But, `self.text_token_indices_flat` is _not_ reset here.  And [it is used](https://github.com/rungalileo/dataquality/blob/main/dataquality/loggers/data_logger/text_ner.py#L599) as one of the columns in the Vaex frame for each batch.
- So when we try to log the second batch, the other columns contain data from only the second batch, but `self.text_token_indices_flat` contains data from both batches together.

This PR resets `self.text_token_indices_flat` inside `self.validate`, which is called once per batch, and is the method where `self.text_token_indices_flat` gets populated.