### PR TITLE
Fix save feature importances

### DIFF
--- a/dataquality/clients/api.py
+++ b/dataquality/clients/api.py
@@ -788,7 +788,7 @@ class ApiClient:
 
     def set_metric_for_run(self, project_id: UUID4, run_id: UUID4, data: Dict) -> Dict:
         return self.make_request(
-            RequestType.POST,
+            RequestType.PUT,
             url=(
                 f"{config.api_url}/{Route.projects}/{project_id}/{Route.runs}/{run_id}/"
                 f"{Route.metrics}"

--- a/dataquality/loggers/data_logger/structured_classification.py
+++ b/dataquality/loggers/data_logger/structured_classification.py
@@ -22,6 +22,7 @@ from vaex.dataframe import DataFrame
 from dataquality.clients.objectstore import ObjectStore
 from dataquality.loggers.data_logger.base_data_logger import BaseGalileoDataLogger
 from dataquality.loggers.logger_config.structured_classification import (
+    StructuredClassificationLoggerConfig,
     structured_classification_logger_config,
 )
 from dataquality.schemas import __data_schema_version__
@@ -32,7 +33,9 @@ api_client = ApiClient()
 
 class StructuredClassificationDataLogger(BaseGalileoDataLogger):
     __logger_name__ = "structured_classification"
-    logger_config = structured_classification_logger_config
+    logger_config: StructuredClassificationLoggerConfig = (
+        structured_classification_logger_config
+    )
 
     def __init__(
         self,
@@ -73,6 +76,8 @@ class StructuredClassificationDataLogger(BaseGalileoDataLogger):
             - logger_config.feature_names to the column names of X if they aren't set
         """
         self.validate()
+
+        assert self.model is not None, "Model must be included to log data."
 
         assert hasattr(self.model, "predict_proba"), (
             "Model must have a predict_proba method. "
@@ -127,8 +132,14 @@ class StructuredClassificationDataLogger(BaseGalileoDataLogger):
         for feature in self.feature_names:
             validate_name(feature)
 
+        if not self.logger_config.feature_importances and hasattr(
+            self.model, "feature_importances_"
+        ):
+            self.logger_config.feature_importances = dict(
+                zip(self.feature_names, self.model.feature_importances_.tolist())
+            )
+
         self.set_probs()
-        self.save_feature_importances()
 
     def set_probs(self) -> None:
         """Sets the probs attribute for the class
@@ -144,11 +155,9 @@ class StructuredClassificationDataLogger(BaseGalileoDataLogger):
 
         Assumes the model is fit
         """
-        suffix = "must be set before saving feature importances"
-        assert self.model, f"Model {suffix}"
-        assert self.feature_names, f"Feature names {suffix}"
-        assert config.current_project_id, f"Project ID {suffix}"
-        assert config.current_run_id, f"Run ID {suffix}"
+        template = " {inp} must be set before saving feature importances"
+        assert config.current_project_id, print(template.format(inp="Project ID"))
+        assert config.current_run_id, print(template.format(inp="Run ID"))
 
         api_client.set_metric_for_run(
             config.current_project_id,
@@ -157,7 +166,7 @@ class StructuredClassificationDataLogger(BaseGalileoDataLogger):
                 "key": "feature_importances",
                 "value": 0,
                 "epoch": 0,
-                "extra": dict(zip(self.feature_names, self.model.feature_importances_)),
+                "extra": self.logger_config.feature_importances,
             },
         )
 
@@ -236,6 +245,8 @@ class StructuredClassificationDataLogger(BaseGalileoDataLogger):
         To Minio:
             bucket/proj-id/run-id/training/prob.hdf5
         """
+        self.save_feature_importances()
+
         print("☁️ Uploading Data")
         objectstore = ObjectStore()
 

--- a/dataquality/loggers/logger_config/structured_classification.py
+++ b/dataquality/loggers/logger_config/structured_classification.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from dataquality.loggers.logger_config.text_classification import (
     TextClassificationLoggerConfig,
 )
@@ -5,7 +7,7 @@ from dataquality.loggers.logger_config.text_classification import (
 
 class StructuredClassificationLoggerConfig(TextClassificationLoggerConfig):
     # NOTE: By inheriting from TCLoggerCongif we get cleaned labels
-    pass
+    feature_importances: Dict[str, float] = {}
 
 
 structured_classification_logger_config = StructuredClassificationLoggerConfig()

--- a/docs/Structured-Data.ipynb
+++ b/docs/Structured-Data.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 1,
    "id": "ba6c8e04-590b-45ac-b537-e0fc3345287f",
    "metadata": {},
    "outputs": [
@@ -47,7 +47,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/elliottchartock/Code/dataquality/.venv/lib/python3.9/site-packages/dataquality/core/init.py:159: UserWarning: Run: structured-elliott/iris-uris-weallris already exists! The existing run will get overwritten on call to finish()!\n",
+      "/Users/elliottchartock/Code/dataquality/.venv/lib/python3.9/site-packages/dataquality/core/init.py:140: UserWarning: Run: structured-elliott/iris-uris-weallris already exists! The existing run will get overwritten on call to finish()!\n",
       "  warnings.warn(\n"
      ]
     }
@@ -66,8 +66,8 @@
     "import dataquality as dq\n",
     "dq.configure()\n",
     "\n",
-    "run_name = \"fine-wine\"\n",
-    "# run_name = \"iris-uris-weallris\"\n",
+    "# run_name = \"fine-wine\"\n",
+    "run_name = \"iris-uris-weallris\"\n",
     "\n",
     "dq.init(\"structured_classification\", \"structured-elliott\", run_name)"
    ]
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 2,
    "id": "a74dbfd7-1a62-40c6-ab26-3f51b7142953",
    "metadata": {},
    "outputs": [],
@@ -99,7 +99,9 @@
     "    X, y = load_iris(as_frame=True, return_X_y=True)\n",
     "\n",
     "# When exporting to hdf5 you can't have col names containing forward slash\n",
-    "X.rename(lambda x: x.replace(\"/\", \"|\"), axis=\"columns\", inplace=True)\n",
+    "X.rename(lambda x: x.replace(\"/\", \"-\"), axis=\"columns\", inplace=True)\n",
+    "X.rename(lambda x: x.replace(\"(\", \"\"), axis=\"columns\", inplace=True)\n",
+    "X.rename(lambda x: x.replace(\")\", \"\"), axis=\"columns\", inplace=True)\n",
     "\n",
     "\n",
     "def understand_dataset(dataset) -> None:\n",
@@ -119,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 3,
    "id": "13c661e8-14f9-4d9f-bdb8-a4033f72faf6",
    "metadata": {},
    "outputs": [
@@ -139,7 +141,7 @@
        "              objective='multi:softprob', predictor=None, ...)"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -159,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 4,
    "id": "d0509913-18d2-48dd-ac0e-239c79d457d4",
    "metadata": {},
    "outputs": [],
@@ -178,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 5,
    "id": "3faa2b4d-fc29-45f7-9207-f92b3fd4aaa9",
    "metadata": {},
    "outputs": [],
@@ -193,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 6,
    "id": "3b5782ec-2693-4810-8c10-1370b0ab614f",
    "metadata": {},
    "outputs": [],
@@ -216,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 7,
    "id": "5d07b384-fda4-4ca6-b5fe-0bd6319ddbe8",
    "metadata": {},
    "outputs": [
@@ -233,11 +235,11 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.02096271514892578,
+       "elapsed": 0.026401042938232422,
        "initial": 0,
        "n": 0,
        "ncols": null,
-       "nrows": 26,
+       "nrows": 21,
        "postfix": null,
        "prefix": "Uploading data to Galileo",
        "rate": null,
@@ -264,11 +266,11 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.019797086715698242,
+       "elapsed": 0.01973891258239746,
        "initial": 0,
        "n": 0,
        "ncols": null,
-       "nrows": 26,
+       "nrows": 21,
        "postfix": null,
        "prefix": "Uploading data to Galileo",
        "rate": null,
@@ -295,11 +297,11 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.015900850296020508,
+       "elapsed": 0.019629716873168945,
        "initial": 0,
        "n": 0,
        "ncols": null,
-       "nrows": 26,
+       "nrows": 21,
        "postfix": null,
        "prefix": "Uploading data to Galileo",
        "rate": null,
@@ -326,11 +328,11 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.019420146942138672,
+       "elapsed": 0.02074909210205078,
        "initial": 0,
        "n": 0,
        "ncols": null,
-       "nrows": 26,
+       "nrows": 21,
        "postfix": null,
        "prefix": "Uploading data to Galileo",
        "rate": null,
@@ -355,10 +357,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Job default successfully submitted. Results will be available soon at https://console.dev.rungalileo.io/insights?projectId=ee785245-7d39-47f8-9f31-4cbf5023fb1a&runId=898d85d9-99b9-47d6-b91b-2dd8b9c0d986&split=training&metric=f1&depHigh=1&depLow=0&taskType=4\n",
+      "Job default successfully submitted. Results will be available soon at https://console.dev.rungalileo.io/insights?projectId=ee785245-7d39-47f8-9f31-4cbf5023fb1a&runId=56175074-567e-47db-b578-3f59e0b72e90&split=training&metric=f1&depHigh=1&depLow=0&taskType=4\n",
       "Waiting for job...\n",
+      "\tSaving processed test data\n",
       "Done! Job finished with status completed\n",
-      "Click here to see your run! https://console.dev.rungalileo.io/insights?projectId=ee785245-7d39-47f8-9f31-4cbf5023fb1a&runId=898d85d9-99b9-47d6-b91b-2dd8b9c0d986&split=training&metric=f1&depHigh=1&depLow=0&taskType=4\n",
+      "Click here to see your run! https://console.dev.rungalileo.io/insights?projectId=ee785245-7d39-47f8-9f31-4cbf5023fb1a&runId=56175074-567e-47db-b578-3f59e0b72e90&split=training&metric=f1&depHigh=1&depLow=0&taskType=4\n",
       "🧹 Cleaning up\n",
       "🧹 Cleaning up\n"
      ]
@@ -366,10 +369,10 @@
     {
      "data": {
       "text/plain": [
-       "'https://console.dev.rungalileo.io/insights?projectId=ee785245-7d39-47f8-9f31-4cbf5023fb1a&runId=898d85d9-99b9-47d6-b91b-2dd8b9c0d986&split=training&metric=f1&depHigh=1&depLow=0&taskType=4'"
+       "'https://console.dev.rungalileo.io/insights?projectId=ee785245-7d39-47f8-9f31-4cbf5023fb1a&runId=56175074-567e-47db-b578-3f59e0b72e90&split=training&metric=f1&depHigh=1&depLow=0&taskType=4'"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/tests/clients/test_api.py
+++ b/tests/clients/test_api.py
@@ -321,7 +321,7 @@ def test_set_metric_for_run(
     }
     api_client.set_metric_for_run(proj_id, run_id, data)
     mock_make_request.assert_called_once_with(
-        RequestType.POST,
+        RequestType.PUT,
         url=f"http://localhost:8088/projects/{proj_id}/runs/{run_id}/metrics",
         body=data,
     )


### PR DESCRIPTION
We were running into issues where:

- if you overwrote a run name, it would delete the feature importances. This was because we wrote the feature importances before `finish()` so it would delete the run in the DB and cascade the metrics. We now save the feature importances in the data logger `upload` after resetting the run name, so we are fine.
- There was also an issue with not json serializing numpy floats, which is fixed with `tolist()`

These have been tested on this run
https://console.dev.rungalileo.io/insights?dataframeColumns=confidence%3B%26data_error_potential%3B%26gold%3B%26petal+length+cm%3B%26petal+width+cm%3B%26pred%3B%26sepal+length+cm%3B%26sepal+width+cm%3B%26text&projectId=ee785245-7d39-47f8-9f31-4cbf5023fb1a&runId=56175074-567e-47db-b578-3f59e0b72e90&taskType=4

With swagger 

<img width="1126" alt="Screen Shot 2023-02-13 at 3 51 41 PM" src="https://user-images.githubusercontent.com/69087256/218600876-05f80bbe-6ef5-4d2d-9503-cd4ab8083cd3.png">
