### PR TITLE
Adding small fix to hf tokenizer

### DIFF
--- a/dataquality/utils/hf_tokenizer.py
+++ b/dataquality/utils/hf_tokenizer.py
@@ -75,7 +75,11 @@ class LabelTokenizer:
         self.previous_word_id = -1
         self.word_ids = self.tokenized_samples.word_ids(batch_index=k)
         # We check ds and ds.features to accomodate HF and arrow datasets
-        if HFCol.ner_tags in self.ds or HFCol.ner_tags in self.ds.features:
+        # Note we need to make sure that ds has an attr "features" to handle
+        # the weird case when type(ds) = datasets.formatting.formatting.LazyBatch
+        if HFCol.ner_tags in self.ds or (
+            hasattr(self.ds, "features") and HFCol.ner_tags in self.ds.features
+        ):
             existing_labels = [
                 self.idx_2_labels[label] for label in self.ds[HFCol.ner_tags][k]
             ]


### PR DESCRIPTION
* [x] I have added tests to `tests` to cover my changes.

***What existing issue does this pull request close?***

closes #539 

Basically, I was noticing in certain instances, our hf integration introduces this very weird type `datasets.formatting.formatting.LazyBatch` which causes the tokenizer to fail. I honestly don't fully understand it but it seems that the check I have added solves for this. See the issue for a more complete discussion. Let me know if this seems reasonable!
