### PR TITLE
Chore/small cleanups

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -30,7 +30,7 @@ If you want to train without a model, you can use the auto framework:
         dataquality.get_insights()
 """
 
-__version__ = "v0.8.21"
+__version__ = "v0.8.23"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/core/__init__.py
+++ b/dataquality/core/__init__.py
@@ -13,7 +13,7 @@ a = Analytics(ApiClient, config)
 
 
 @check_noop
-def configure(do_login: bool = True) -> None:
+def configure(do_login: bool = True, _internal: bool = False) -> None:
     """[Not for cloud users] Update your active config with new information
 
     You can use environment variables to set the config, or wait for prompts
@@ -23,9 +23,11 @@ def configure(do_login: bool = True) -> None:
     * GALILEO_PASSWORD
     """
     a.log_function("dq/configure")
-    warnings.warn(
-        "configure is deprecated, use dq.set_console_url and dq.login", GalileoWarning
-    )
+    if not _internal:
+        warnings.warn(
+            "configure is deprecated, use dq.set_console_url and dq.login",
+            GalileoWarning,
+        )
 
     if "GALILEO_API_URL" in os.environ:
         del os.environ["GALILEO_API_URL"]
@@ -51,4 +53,4 @@ def set_console_url(console_url: Optional[str] = None) -> None:
     a.log_function("dq/set_console_url")
     if console_url:
         os.environ["GALILEO_CONSOLE_URL"] = console_url
-    configure(do_login=False)
+    configure(do_login=False, _internal=True)

--- a/dataquality/core/log.py
+++ b/dataquality/core/log.py
@@ -370,12 +370,12 @@ def log_model_outputs(
 
     model_logger = get_model_logger(
         task_type=None,
-        embs=embs,
+        embs=embs.astype(np.float32) if isinstance(embs, np.ndarray) else embs,
         ids=ids,
         split=Split[split].value if split else "",
         epoch=epoch,
-        logits=logits,
-        probs=probs,
+        logits=logits.astype(np.float32) if isinstance(logits, np.ndarray) else logits,
+        probs=probs.astype(np.float32) if isinstance(probs, np.ndarray) else probs,
         inference_name=inference_name,
     )
     model_logger.log()

--- a/dataquality/integrations/hf.py
+++ b/dataquality/integrations/hf.py
@@ -192,11 +192,11 @@ def tokenize_and_log_dataset(
         else:
             dq_split = conform_split(ds_key)
 
+        # Filter out rows with no tokens
+        dataset = dataset.filter(lambda row: len(row[HFCol.text_token_indices]) != 0)
         ids = list(range(len(dataset)))
         dataset = dataset.add_column(HFCol.id, ids)
         ds_orig_len = len(dataset)
-        # Filter out rows with no tokens
-        dataset = dataset.filter(lambda row: len(row[HFCol.text_token_indices]) != 0)
         ds_len = len(dataset)
         if ds_orig_len != ds_len:
             warnings.warn(

--- a/dataquality/loggers/data_logger/base_data_logger.py
+++ b/dataquality/loggers/data_logger/base_data_logger.py
@@ -228,6 +228,13 @@ class BaseGalileoDataLogger(BaseGalileoLogger):
 
         if cuml_available():
             apply_umap_to_embs(location, last_epoch)
+        else:
+            print(
+                "CuML libraries not found, running standard process. "
+                "For faster Galileo processing, consider installing\n"
+                "`pip install 'dataquality[cuda]' --extra-index-url="
+                "https://pypi.ngc.nvidia.com/`"
+            )
 
         if cuml_available() and create_data_embs and self.support_data_embs:
             print("Creating and uploading data embeddings")

--- a/dataquality/loggers/model_logger/text_classification.py
+++ b/dataquality/loggers/model_logger/text_classification.py
@@ -1,4 +1,3 @@
-import warnings
 from enum import Enum, unique
 from typing import Any, Dict, List, Optional, Union
 
@@ -128,7 +127,6 @@ class TextClassificationModelLogger(BaseGalileoModelLogger):
             self.probs = self.convert_logits_to_probs(self.logits)
             del self.logits
         elif has_probs:
-            warnings.warn("Usage of probs is deprecated, use logits instead")
             self.probs = self._convert_tensor_ndarray(self.probs, "Prob")
 
         self.embs = self._convert_tensor_ndarray(self.embs, "Embedding")

--- a/dataquality/loggers/model_logger/text_ner.py
+++ b/dataquality/loggers/model_logger/text_ner.py
@@ -1,4 +1,3 @@
-import warnings
 from collections import defaultdict
 from enum import Enum, unique
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple, Union
@@ -146,7 +145,6 @@ class TextNERModelLogger(BaseGalileoModelLogger):
         if len(self.logits):
             self.probs = self.convert_logits_to_probs(self.logits)
         elif len(self.probs):
-            warnings.warn("Usage of probs is deprecated, use logits instead")
             self.probs = self._convert_tensor_ndarray(self.probs)
 
         embs_len = len(self.embs)

--- a/dataquality/utils/cuda.py
+++ b/dataquality/utils/cuda.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+PCA_CHUNK_SIZE = 100_000
+
 
 def cuml_available() -> bool:
     try:
@@ -17,7 +19,7 @@ def get_pca_embeddings(embs: np.ndarray) -> np.ndarray:
     """
     import cuml
 
-    pca = cuml.PCA(n_components=100)
+    pca = cuml.IncrementalPCA(n_components=100, chunk_size=PCA_CHUNK_SIZE)
     return pca.fit_transform(embs)
 
 


### PR DESCRIPTION
small improvements here and there

1. fix the `configure` warning when calling `set_console_url` - add an `_internal` flag that removes warning
2. downcast to float32 when logging. This saves huge amounts of space if they are logging f64 (like i was today during testing amazon polarity)
3. in our hf tokenizer, first filter then add IDs, just to make the ids continuous (noop, just nicer)
4. add a print to encourage people to install dq with the cuda extra
5. remove the deprecation on probs, users can use whatever they prefer
6. Do incremental PCA instead of PCA during the GPU UMAP phase, because it's more memory efficient
7. use `with torch.autocast("cuda"):` when creating data embeddings, it speeds things up by around 10 sentences/sec during testing with amazon polarity (thanks Derek!)