### PR TITLE
add split names val and valid

### DIFF
--- a/dataquality/schemas/split.py
+++ b/dataquality/schemas/split.py
@@ -5,8 +5,10 @@ from dataquality.exceptions import GalileoException
 
 
 class Split(str, Enum):
-    training = "training"
     train = "training"
+    training = "training"
+    val = "validation"
+    valid = "validation"
     validation = "validation"
     test = "test"
     testing = "test"
@@ -18,7 +20,7 @@ class Split(str, Enum):
 
     @staticmethod
     def get_valid_keys() -> List[str]:
-        return ["train", "training", "test", "testing", "validation"]
+        return ["train", "training", "val", "valid", "validation", "test", "testing"]
 
 
 def conform_split(split: Union[str, Split]) -> Split:


### PR DESCRIPTION
Added "val" and "valid" as acceptable split names for the validation split

This was needed for IC, since the split name determines the name of the val folder, which sometimes is "val" or "valid" instead of "validation"
