### PR TITLE
Feature/auto seeding

### DIFF
--- a/dataquality/dq_auto/ner_trainer.py
+++ b/dataquality/dq_auto/ner_trainer.py
@@ -70,9 +70,11 @@ def get_trainer(
     #  not an Optional[DatasetDict]...?
     assert isinstance(encoded_datasets, DatasetDict)
 
-    model = AutoModelForTokenClassification.from_pretrained(
-        model_checkpoint, num_labels=len(dq.get_model_logger().logger_config.labels)
-    )
+    # Used to properly seed the model
+    def model_init():
+        return AutoModelForTokenClassification.from_pretrained(
+            model_checkpoint, num_labels=len(dq.get_model_logger().logger_config.labels)
+        )
 
     batch_size = 64
     has_val = Split.validation in encoded_datasets
@@ -96,8 +98,8 @@ def get_trainer(
 
     # We pass huggingface datasets here but typing expects torch datasets, so we ignore
     trainer = Trainer(
-        model,
-        args,
+        model_init=model_init,
+        args=args,
         train_dataset=encoded_datasets[Split.train],  # type: ignore
         eval_dataset=encoded_datasets.get(Split.validation),  # type: ignore
         tokenizer=tokenizer,

--- a/dataquality/dq_auto/ner_trainer.py
+++ b/dataquality/dq_auto/ner_trainer.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import evaluate
 import numpy as np
@@ -71,7 +71,7 @@ def get_trainer(
     assert isinstance(encoded_datasets, DatasetDict)
 
     # Used to properly seed the model
-    def model_init():
+    def model_init() -> Any:
         return AutoModelForTokenClassification.from_pretrained(
             model_checkpoint, num_labels=len(dq.get_model_logger().logger_config.labels)
         )

--- a/dataquality/dq_auto/tc_trainer.py
+++ b/dataquality/dq_auto/tc_trainer.py
@@ -55,9 +55,11 @@ def get_trainer(
         lambda x: preprocess_function(x, tokenizer, max_padding_length), batched=True
     )
 
-    model = AutoModelForSequenceClassification.from_pretrained(
-        model_checkpoint, num_labels=len(labels)
-    )
+    # Used to properly seed the model
+    def model_init():
+        return AutoModelForSequenceClassification.from_pretrained(
+            model_checkpoint, num_labels=len(labels)
+        )
 
     # Training arguments and training part
     metric = evaluate.load(EVAL_METRIC)
@@ -84,8 +86,8 @@ def get_trainer(
 
     # We pass huggingface datasets here but typing expects torch datasets, so we ignore
     trainer = Trainer(
-        model,
-        args,
+        model_init=model_init,
+        args=args,
         train_dataset=encoded_datasets[Split.train],  # type: ignore
         eval_dataset=encoded_datasets.get(Split.validation),  # type: ignore
         tokenizer=tokenizer,

--- a/dataquality/dq_auto/tc_trainer.py
+++ b/dataquality/dq_auto/tc_trainer.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import evaluate
 import numpy as np
@@ -56,7 +56,7 @@ def get_trainer(
     )
 
     # Used to properly seed the model
-    def model_init():
+    def model_init() -> Any:
         return AutoModelForSequenceClassification.from_pretrained(
             model_checkpoint, num_labels=len(labels)
         )


### PR DESCRIPTION
* [x] I have added tests to `tests` to cover my changes.
* [ ] I have updated `docs/`, if necessary.
* [ ] I have updated the `README.md`, if necessary.

***What existing issue does this pull request close?***

Addressed this ticket: https://app.shortcut.com/galileo/story/4746/updated-seeding-in-dq-auto

***Resources + testing***

I followed this [thread](https://discuss.huggingface.co/t/fixing-the-random-seed-in-the-trainer-does-not-produce-the-same-results-across-runs/3442/3) on the hf discussion page.

Additionally, to test this I ran three different training jobs in a Colab 1) baseline using the new seeding, 2) a second run using the new seeding, and 3) a third run where we just seed the Trainer not the model. As confirmation, runs 1 + 2 had the exact same results, while run 3 did not.
