### PR TITLE
Fixes/memory leak img

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -30,7 +30,7 @@ If you want to train without a model, you can use the auto framework:
         dataquality.get_insights()
 """
 
-__version__ = "v0.8.30"
+__version__ = "v0.8.31"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/loggers/data_logger/image_classification.py
+++ b/dataquality/loggers/data_logger/image_classification.py
@@ -1,5 +1,5 @@
-import hashlib
 import os
+import tempfile
 from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
@@ -18,7 +18,7 @@ from dataquality.loggers.logger_config.image_classification import (
 )
 from dataquality.schemas.dataframe import BaseLoggerDataFrames
 from dataquality.schemas.split import Split
-from dataquality.utils.upload import upload_df
+from dataquality.utils.upload import chunk_load_then_upload_df
 
 # smaller than ITER_CHUNK_SIZE from base_data_logger because very large chunks
 # containing image data often won't fit in memory
@@ -126,30 +126,17 @@ class ImageClassificationDataLogger(TextClassificationDataLogger):
         file_list = dataset[imgs_location_colname].tolist()
         project_id = config.current_project_id
 
-        def load_bytes_from_file(file_path: str) -> Dict[str, Union[str, bytes]]:
-            with open(file_path, "rb") as f:
-                img = f.read()
-                hash = hashlib.md5(img).hexdigest()
-                ext = os.path.splitext(file_path)[1]
-                return {
-                    "data": img,
-                    "object_path": f"{project_id}/{hash}{ext}",
-                }
-
-        df = vaex.from_records(
-            list(
-                map(
-                    load_bytes_from_file,
-                    [f for f in file_list],
-                )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            export_format = "arrow"
+            chunk_load_then_upload_df(
+                file_list=file_list,
+                export_cols=["data", "object_path"],
+                project_id=project_id,
+                temp_dir=temp_dir,
+                parallel=parallel,
+                export_format=export_format,
             )
-        )
-        upload_df(
-            df=df,
-            export_cols=["data", "object_path"],
-            project_id=project_id,
-            parallel=parallel,
-        )
+            df = vaex.open(f"{temp_dir}/*.arrow")
         dataset["text"] = df["object_path"].to_numpy()
 
         return dataset


### PR DESCRIPTION
Temporary fix that chunks the image files upload without loading all images into memory.
Caveat. I'm not sure if the file is still uploaded twice as I can see a file exists check and upload the blob data,
