### PR TITLE
Cuda extra updates

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -30,7 +30,7 @@ If you want to train without a model, you can use the auto framework:
         dataquality.get_insights()
 """
 
-__version__ = "v0.8.33"
+__version__ = "v0.8.34"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/loggers/data_logger/base_data_logger.py
+++ b/dataquality/loggers/data_logger/base_data_logger.py
@@ -233,7 +233,7 @@ class BaseGalileoDataLogger(BaseGalileoLogger):
                 "CuML libraries not found, running standard process. "
                 "For faster Galileo processing, consider installing\n"
                 "`pip install 'dataquality[cuda]' --extra-index-url="
-                "https://pypi.ngc.nvidia.com/`"
+                "https://pypi.nvidia.com/`"
             )
 
         if cuml_available() and create_data_embs and self.support_data_embs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,16 +84,15 @@ dev = [
     "evaluate",
 ]
 
-# Need to be installed with `pip install 'dataquality[cuda]' --extra-index-url=https://pypi.ngc.nvidia.com/ `
-# Need to pin because the new release is broken https://github.com/rapidsai/cudf/issues/12762#issuecomment-1462845289
+# Need to be installed with `pip install 'dataquality[cuda]' --extra-index-url=https://pypi.nvidia.com/ `
 cuda = [
-   "ucx-py-cu11<0.30",
-   "rmm-cu11==22.12",
-   "raft-dask-cu11==22.12",
-   "pylibraft-cu11==22.12",
-   "dask-cudf-cu11==22.12",
-   "cudf-cu11==22.12",
-   "cuml-cu11==22.12"
+   "ucx-py-cu11<=0.30",
+   "rmm-cu11==23.2.0",
+   "raft-dask-cu11==23.2.0",
+   "pylibraft-cu11==23.2.0",
+   "dask-cudf-cu11==23.2.0",
+   "cudf-cu11==23.2.0",
+   "cuml-cu11==23.2.0"
 ]
 
 minio = [


### PR DESCRIPTION
old release environment (`pypi.ngc...`) seems to have been taken down. 

I tested these versions in colab and they work for us. Updating dq version so we can release a working version out to customers