### PR TITLE
added setfit support

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -30,7 +30,7 @@ If you want to train without a model, you can use the auto framework:
         dataquality.get_insights()
 """
 
-__version__ = "v0.8.37"
+__version__ = "v0.8.38"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/integrations/setfit.py
+++ b/dataquality/integrations/setfit.py
@@ -36,7 +36,7 @@ class PatchManager(Borg):
     def unpatch(self) -> None:
         """Unpatch all patches"""
         for patch in self.patches[:]:
-            patch.unpatch()
+            patch._unpatch()
             self.patches.remove(patch)
 
 
@@ -55,8 +55,13 @@ class Patch(ABC):
     def _patch(self) -> "Patch":
         """Abstract patch function. Returns patch object."""
 
+    @abstractmethod
+    def _unpatch(self) -> None:
+        """Abstract unpatch function."""
+
     def unpatch(self) -> None:
         """Unpatch function. Call _unpatch function and removes patch from manager."""
+        print("unpatching", self.name)
         self.manager.unpatch()
 
 
@@ -139,6 +144,7 @@ class _PatchSetFitModel(Patch):
         """
         self.model = setfit_model
         self.function_name = function_name
+        self.patch()
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         """Call unpatch SetFit model and then the save_pretrained function."""
@@ -157,8 +163,8 @@ class _PatchSetFitModel(Patch):
 
     def _unpatch(self) -> None:
         """Unpatch SetFit model by replacing save_pretrained"""
-        print("unpatching")
         setattr(self.model, self.function_name, self.old_fn)
+        print("unpatched", self.name)
 
 
 class _PatchSetFitTrainer(Patch):
@@ -267,6 +273,7 @@ class _PatchSetFitTrainer(Patch):
         """Unpatch SetFit trainer by replacing the patched train function with
         original function."""
         setattr(self.trainer, self.function_name, self.old_fn)
+        print("unpatched", self.name)
 
 
 def watch(

--- a/dataquality/integrations/setfit.py
+++ b/dataquality/integrations/setfit.py
@@ -1,0 +1,128 @@
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+from torch import Tensor
+
+import dataquality as dq
+from dataquality.schemas.split import Split
+from dataquality.utils.cleanup import Cleanup, RefManager
+
+
+class SetFitModelHook:
+    def __init__(
+        self,
+        setfit_model: Any,
+        store: Dict = None,
+        func_name="predict_proba",
+        n_labels=None,
+    ) -> None:
+        """
+        Hook to SetFit model to store input and output of predict_proba function.
+        :param setfit_model: SetFit model
+        :param store: dictionary to store input and output
+        :param func_name: name of function to hook
+        :param n_labels: number of labels
+        """
+        self.in_cls = setfit_model
+        if store is not None:
+            self.store = store
+        else:
+            self.store = {}
+
+        self.func_name = "model_head"
+        self.func_name_predict = func_name
+        self.n_labels = n_labels
+        self.setup()
+
+    def setup(self) -> None:
+        """Setup hook to SetFit model by replacing predict_proba function with self."""
+
+        self.old_model = getattr(self.in_cls, self.func_name)
+        self.old_func = getattr(self.old_model, self.func_name_predict)
+        setattr(self.old_model, self.func_name_predict, self)
+        self.store["hook"] = self
+
+    def __call__(self, *args: Tuple, **kwargs: Dict) -> Any:
+        """Call predict_proba function and store input and output.
+        :param args: arguments of predict_proba function
+        :param kwargs: keyword arguments of predict_proba function
+        :return: output of predict_proba function"""
+        self.store["input_args"] = args
+        self.store["input_kwargs"] = kwargs
+        output = self.old_func(*args, **kwargs)
+        if self.func_name == "predict":
+            self.store["output"] = np.eye(self.n_values)[output]
+        self.store["output"] = output
+        return output
+
+    def unpatch(self):
+        """Unpatch SetFit model by replacing predict_proba
+        function with old function."""
+        setattr(self.old_model, self.func_name_predict, self.old_func)
+
+
+def watch(model: Any) -> Dict:
+    """Watch SetFit model by replacing predict_proba function with SetFitModelHook.
+    :param model: SetFit model
+    :return: SetFitModelHook object"""
+    dq_hook = SetFitModelHook(model)
+    dq_store = dq_hook.store
+    labels = dq.get_data_logger().logger_config.labels
+
+    def dq_evaluate(
+        batch: Dict,
+        split: Split,
+        inference_name: Optional[str] = None,
+        column_mapping: Optional[Dict] = {
+            "text": "text",
+            "id": "id",
+            "label": "label",
+        },
+    ) -> Tensor:
+        """Evaluate SetFit model and log input and output to Galileo.
+        :param batch: batch of data as a dictionary
+        :param split: split of data (training, validation, test, inference)
+        :param inference_name: inference name (if split is inference, must be provided)
+        :param column_mapping: mapping of column names (if different from default)
+        :return: output of SetFitModel.predict_proba function"""
+
+        text_col = "text"
+        id_col = "id"
+        label_col = "label"
+        if column_mapping is not None:
+            text_col = column_mapping[text_col]
+            id_col = column_mapping[id_col]
+            label_col = column_mapping[label_col]
+
+        assert text_col in batch, f"column '{text_col}' must be in batch"
+        assert id_col in batch, f"column '{id_col}' text must be in batch"
+
+        preds = model.predict_proba(batch[text_col])
+        # 🔭🌕 Galileo logging
+        log_args = dict(texts=batch["text"], ids=batch[id_col], split=split)
+        if inference_name is not None:
+            log_args["inference_name"] = inference_name
+            inference_dict = {"inference_name": inference_name}
+        else:
+            assert label_col in batch, f"column '{label_col}' must be in batch"
+            log_args["labels"] = [labels[label] for label in batch[label_col]]
+            inference_dict = {}
+        helper_data = dq.get_data_logger().logger_config.helper_data
+
+        # Unpatch SetFit model after logging (when finished is called)
+        cleanup_manager = RefManager(dq_hook.unpatch)
+        helper_data["cleaner"] = Cleanup(cleanup_manager)
+
+        dq.log_data_samples(**log_args)
+        # 🔭🌕 Galileo logging
+        dq.log_model_outputs(
+            ids=batch[id_col],
+            logits=dq_store["output"],
+            embs=dq_store["input_args"][0],
+            split=split,
+            epoch=0,
+            **inference_dict,
+        )
+        return preds
+
+    return dq_evaluate

--- a/dataquality/integrations/setfit.py
+++ b/dataquality/integrations/setfit.py
@@ -48,12 +48,12 @@ class Patch(ABC):
     def patch(self) -> None:
         """Patch function. Call _patch function and adds patch to manager."""
         patch = self._patch()
+        print("patching", self.name)
         self.manager.add_patch(patch)
 
     @abstractmethod
     def _patch(self) -> "Patch":
         """Abstract patch function. Returns patch object."""
-        pass
 
     def unpatch(self) -> None:
         """Unpatch function. Call _unpatch function and removes patch from manager."""
@@ -62,6 +62,8 @@ class Patch(ABC):
 
 class SetFitModelHook(Patch):
     """Hook to SetFit model to store input and output of predict_proba function."""
+
+    name = "setfit_predict"
 
     def __init__(
         self,
@@ -126,6 +128,8 @@ class SetFitModelHook(Patch):
 class _PatchSetFitModel(Patch):
     """Patch to SetFit model to unpatch when calling save_pretrained function."""
 
+    name = "setfit_save_pretrained"
+
     def __init__(
         self, setfit_model: SetFitModel, function_name: str = "save_pretrained"
     ) -> None:
@@ -153,11 +157,14 @@ class _PatchSetFitModel(Patch):
 
     def _unpatch(self) -> None:
         """Unpatch SetFit model by replacing save_pretrained"""
+        print("unpatching")
         setattr(self.model, self.function_name, self.old_fn)
 
 
 class _PatchSetFitTrainer(Patch):
     """Patch to SetFit trainer to run dataquality after training."""
+
+    name = "setfit_trainer"
 
     def __init__(
         self,

--- a/dataquality/integrations/setfit.py
+++ b/dataquality/integrations/setfit.py
@@ -1,10 +1,13 @@
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
 
 import numpy as np
 
 import dataquality as dq
 from dataquality.schemas.split import Split
 from dataquality.utils.cleanup import Cleanup, RefManager
+
+if TYPE_CHECKING:
+    from setfit import SetFitModel, SetFitTrainer
 
 
 class SetFitModelHook:
@@ -28,7 +31,7 @@ class SetFitModelHook:
         else:
             self.store = {}
 
-        self.func_name = "model_head"
+        self.cls_name = "model_head"
         self.func_name_predict = func_name
         self.n_labels = n_labels
         self.setup()
@@ -36,9 +39,13 @@ class SetFitModelHook:
     def setup(self) -> None:
         """Setup hook to SetFit model by replacing predict_proba function with self."""
 
-        self.old_model = getattr(self.in_cls, self.func_name)
+        self.old_model = getattr(self.in_cls, self.cls_name)
         self.old_func = getattr(self.old_model, self.func_name_predict)
         setattr(self.old_model, self.func_name_predict, self)
+        unpatch = _PatchSetFitModel(
+            self.in_cls,
+        )
+        unpatch.model_unpatch = self.unpatch
         self.store["hook"] = self
 
     def __call__(self, *args: Tuple, **kwargs: Dict) -> Any:
@@ -49,7 +56,7 @@ class SetFitModelHook:
         self.store["input_args"] = args
         self.store["input_kwargs"] = kwargs
         output = self.old_func(*args, **kwargs)
-        if self.func_name == "predict":
+        if self.cls_name == "predict":
             assert self.n_labels is not None, "n_labels must be set"
             self.store["output"] = np.eye(self.n_labels)[output]
         self.store["output"] = output
@@ -61,7 +68,107 @@ class SetFitModelHook:
         setattr(self.old_model, self.func_name_predict, self.old_func)
 
 
-def watch(model: Any) -> Callable:
+class _PatchSetFitModel:
+    def __init__(
+        self, setfit_model: SetFitModel, function_name: str = "save_pretrained"
+    ) -> None:
+        self.model = setfit_model
+        self.old_fn = getattr(self.model, function_name)
+        setattr(self.model, function_name, self)
+
+    def __call__(self, *args: Any, **kwds: Any) -> Any:
+        self.unpatch()
+        self.model_unpatch()
+        return self.old_fn(*args, **kwds)
+
+    def unpatch(self) -> None:
+        setattr(self.model, self.old_fn)
+
+
+class _PatchSetFitTrainer:
+    def __init__(
+        self, setfit_trainer: SetFitTrainer, function_name: str = "train"
+    ) -> None:
+        self.trainer = setfit_trainer
+        self.old_fn = getattr(self.trainer, function_name)
+        setattr(self.trainer, function_name, self)
+
+    def __call__(self, *args: Any, **kwds: Any) -> Any:
+        batch_size = kwds.get("batch_size", self.trainer.batch_size)
+        if batch_size is not None and len(args) > 0:
+            batch_size = args[1]
+
+        res = self.old_fn(*args, **kwds)
+        model = self.trainer.model
+        dq_hook = SetFitModelHook(model)
+        dq_store = dq_hook.store
+        train_dataset = self.trainer.train_dataset
+        eval_dataset = self.trainer.eval_dataset
+
+        if self.column_mapping is not None:
+            train_dataset = self.trainer._apply_column_mapping(
+                train_dataset, self.trainer.column_mapping
+            )
+
+        labels = dq.get_data_logger().logger_config.labels
+        dq.init("text_classification", project_name="setfit", run_name="test")
+        if not labels:
+            labels = train_dataset.features["label"].names
+        dq.set_labels_for_run(labels)
+        datasets = [train_dataset]
+        if eval_dataset is not None:
+            if self.column_mapping is not None:
+                eval_dataset = self.trainer._apply_column_mapping(
+                    eval_dataset, self.trainer.column_mapping
+                )
+            datasets.append(eval_dataset)
+        for split in [Split.training, Split.validation]:
+            if split == Split.training:
+                dataset = train_dataset
+            else:
+                dataset = eval_dataset
+            if dataset is None:
+                continue
+            if "id" not in dataset.features:
+                dataset = dataset.map(lambda x, idx: {"id": idx}, with_indices=True)
+            for i in range(0, len(dataset), batch_size):
+                batch = dataset[i : i + batch_size]
+                model.predict_proba(batch["text"])
+                # 🔭🌕 Galileo logging
+                dq.log_data_samples(
+                    texts=batch["text"],
+                    ids=batch["id"],
+                    labels=[labels[label_id] for label_id in batch["label"]],
+                    split=split,
+                )
+                # 🔭🌕 Galileo logging
+                dq.log_model_outputs(
+                    ids=batch["id"],
+                    logits=dq_store["output"],
+                    embs=dq_store["input_args"][0],
+                    split=split,
+                    epoch=0,
+                )
+
+        return res
+
+    def unpatch(self) -> None:
+        setattr(self.trainer, self.old_fn)
+
+
+def watch(setfit: Union[SetFitModel, SetFitTrainer]) -> Optional[Callable]:
+    """Watch SetFit model by replacing predict_proba function with SetFitModelHook.
+    :param model: SetFit model"""
+    model = setfit
+
+    if isinstance(setfit, SetFitTrainer):
+        model = setfit.model
+        _PatchSetFitTrainer(setfit, "train")
+    else:
+        return evaluate(model)
+
+
+def evaluate(model: SetFitModel) -> Callable:
     """Watch SetFit model by replacing predict_proba function with SetFitModelHook.
     :param model: SetFit model
     :return: SetFitModelHook object"""

--- a/dataquality/integrations/setfit.py
+++ b/dataquality/integrations/setfit.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
-from torch import Tensor
 
 import dataquality as dq
 from dataquality.schemas.split import Split
@@ -13,7 +12,7 @@ class SetFitModelHook:
         self,
         setfit_model: Any,
         store: Optional[Dict] = None,
-        func_name="predict_proba",
+        func_name: str = "predict_proba",
         n_labels=None,
     ) -> None:
         """
@@ -100,13 +99,14 @@ def watch(model: Any) -> Dict:
         preds = model.predict_proba(batch[text_col])
         # 🔭🌕 Galileo logging
         log_args = dict(texts=batch["text"], ids=batch[id_col], split=split)
+        inference_dict: Dict[str, str] = {}
         if inference_name is not None:
             log_args["inference_name"] = inference_name
-            inference_dict: Dict[str, str] = {"inference_name": inference_name}
+            inference_dict["inference_name"] = inference_name
         else:
             assert label_col in batch, f"column '{label_col}' must be in batch"
             log_args["labels"] = [labels[label] for label in batch[label_col]]
-            inference_dict: Dict[str, str] = {}
+
         helper_data = dq.get_data_logger().logger_config.helper_data
 
         # Unpatch SetFit model after logging (when finished is called)

--- a/dataquality/integrations/setfit.py
+++ b/dataquality/integrations/setfit.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import numpy as np
 
@@ -13,7 +13,7 @@ class SetFitModelHook:
         setfit_model: Any,
         store: Optional[Dict] = None,
         func_name: str = "predict_proba",
-        n_labels=None,
+        n_labels: Optional[int] = None,
     ) -> None:
         """
         Hook to SetFit model to store input and output of predict_proba function.
@@ -50,6 +50,7 @@ class SetFitModelHook:
         self.store["input_kwargs"] = kwargs
         output = self.old_func(*args, **kwargs)
         if self.func_name == "predict":
+            assert self.n_labels is not None, "n_labels must be set"
             self.store["output"] = np.eye(self.n_labels)[output]
         self.store["output"] = output
         return output
@@ -60,7 +61,7 @@ class SetFitModelHook:
         setattr(self.old_model, self.func_name_predict, self.old_func)
 
 
-def watch(model: Any) -> Dict:
+def watch(model: Any) -> Callable:
     """Watch SetFit model by replacing predict_proba function with SetFitModelHook.
     :param model: SetFit model
     :return: SetFitModelHook object"""

--- a/dataquality/integrations/setfit.py
+++ b/dataquality/integrations/setfit.py
@@ -83,7 +83,6 @@ class Patch(ABC):
     def patch(self) -> None:
         """Patch function. Call _patch function and adds patch to manager."""
         patch = self._patch()
-        print("patching", self.name)
         self.manager.add_patch(patch)
 
     @abstractmethod
@@ -96,7 +95,6 @@ class Patch(ABC):
 
     def unpatch(self) -> None:
         """Unpatch function. Call _unpatch function and removes patch from manager."""
-        print("unpatching", self.name)
         self.manager.unpatch()
 
 
@@ -199,7 +197,6 @@ class _PatchSetFitModel(Patch):
     def _unpatch(self) -> None:
         """Unpatch SetFit model by replacing save_pretrained"""
         setattr(self.model, self.function_name, self.old_fn)
-        print("unpatched", self.name)
 
 
 class _PatchSetFitTrainer(Patch):
@@ -318,7 +315,15 @@ class _PatchSetFitTrainer(Patch):
         """Unpatch SetFit trainer by replacing the patched train function with
         original function."""
         setattr(self.trainer, self.function_name, self.old_fn)
-        print("unpatched", self.name)
+
+
+def unwatch(setfit_obj: Union["SetFitModel", "SetFitTrainer"]) -> None:
+    """Unpatch SetFit model by replacing predict_proba function with original
+    function.
+    :param setfit_obj: SetFitModel or SetFitTrainer
+    """
+    setfitmanager = PatchManager()
+    setfitmanager.unpatch()
 
 
 def watch(

--- a/dataquality/integrations/setfit.py
+++ b/dataquality/integrations/setfit.py
@@ -20,6 +20,10 @@ def _apply_column_mapping(
     Applies the provided column mapping to the dataset, renaming columns accordingly.
     Extra features not in the column mapping are prefixed with `"feat_"`.
     """
+    if type(dataset) == dict:
+        from datasets import Dataset
+
+        dataset = Dataset.from_dict(dataset)
     dataset = dataset.rename_columns(
         {
             **column_mapping,

--- a/dataquality/utils/cleanup.py
+++ b/dataquality/utils/cleanup.py
@@ -1,5 +1,5 @@
-from typing import Any, Callable
 import weakref
+from typing import Any, Callable
 
 
 class RefManager:

--- a/dataquality/utils/cleanup.py
+++ b/dataquality/utils/cleanup.py
@@ -10,8 +10,8 @@ class RefManager:
         """Initialize the cleanup manager.
         :param cleanup_func: The function to call when an object is garbage
         collected."""
-        self.cleanup_func = cleanup_func
-        self._instances = set()
+        self.cleanup_func: Callable = cleanup_func
+        self._instances: set = set()
 
     def register(self, instance: Any) -> None:
         """Register an object with the cleanup manager.

--- a/dataquality/utils/cleanup.py
+++ b/dataquality/utils/cleanup.py
@@ -1,0 +1,26 @@
+import weakref
+
+
+class RefManager:
+    def __init__(self, cleanup_func):
+        self.cleanup_func = cleanup_func
+        self._instances = set()
+
+    def register(self, instance):
+        weak_instance = weakref.ref(instance, self._cleanup_callback)
+        self._instances.add(weak_instance)
+
+    def _cleanup_callback(self, weak_instance):
+        self.cleanup_func()
+        self._instances.discard(weak_instance)
+
+
+class Cleanup:
+    def __init__(self, cleanup_manager):
+        self.cleanup_manager = cleanup_manager
+        self.cleanup_manager.register(self)
+
+    def __del__(self):
+        # This will be called when the object is garbage collected.
+        # However, it's not guaranteed to be called in all situations.
+        self.cleanup_manager._cleanup_callback(weakref.ref(self))

--- a/dataquality/utils/cleanup.py
+++ b/dataquality/utils/cleanup.py
@@ -1,26 +1,44 @@
+from typing import Any, Callable
 import weakref
 
 
 class RefManager:
-    def __init__(self, cleanup_func):
+    """Manage weak references to objects and call a cleanup function when
+    the object is garbage collected."""
+
+    def __init__(self, cleanup_func: Callable):
+        """Initialize the cleanup manager.
+        :param cleanup_func: The function to call when an object is garbage
+        collected."""
         self.cleanup_func = cleanup_func
         self._instances = set()
 
-    def register(self, instance):
+    def register(self, instance: Any) -> None:
+        """Register an object with the cleanup manager.
+        :param instance: The object to register."""
         weak_instance = weakref.ref(instance, self._cleanup_callback)
         self._instances.add(weak_instance)
 
-    def _cleanup_callback(self, weak_instance):
+    def _cleanup_callback(self, weak_instance: Any) -> None:
+        """Call the cleanup function when the object is garbage collected.
+        :param weak_instance: The weak reference to the object that was
+        garbage collected."""
         self.cleanup_func()
         self._instances.discard(weak_instance)
 
 
 class Cleanup:
-    def __init__(self, cleanup_manager):
+    """Base class for objects that need to be cleaned up when they are
+    garbage collected."""
+
+    def __init__(self, cleanup_manager: RefManager) -> None:
+        """Register this object with the cleanup manager.
+        :param cleanup_manager: The cleanup manager to register with."""
         self.cleanup_manager = cleanup_manager
         self.cleanup_manager.register(self)
 
-    def __del__(self):
+    def __del__(self) -> None:
+        """Call the cleanup function when the object is garbage collected."""
         # This will be called when the object is garbage collected.
         # However, it's not guaranteed to be called in all situations.
         self.cleanup_manager._cleanup_callback(weakref.ref(self))

--- a/docs/autodocs/api/dataquality.rst
+++ b/docs/autodocs/api/dataquality.rst
@@ -47,6 +47,20 @@ dataquality.integrations.hf
     :show-inheritance:
     :member-order: bysource
 
+dataquality.integrations.fastai
+-----------
+.. automodule:: dataquality.integrations.fastai
+    :members: FastAiDQCallback
+    :show-inheritance:
+    :member-order: bysource
+
+dataquality.integrations.setfit
+-----------
+.. automodule:: dataquality.integrations.fastai
+    :members: watch, unwatch
+    :show-inheritance:
+    :member-order: bysource
+
 dataquality
 -----------
 .. automodule:: dataquality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,8 @@ test = [
     "timm>=0.6.12",
     "fastai>=2.7.11",
     "portalocker==2.7.0",
-    "types-PyYAML==6.0.12.9"
+    "types-PyYAML==6.0.12.9",
+    "setfit"
 ]
 dev = [
     "flake8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,10 @@ evaluate = [
     "evaluate"
 ]
 
+setfit = [
+    "setfit"
+]
+
 [tool.isort]
 profile = "black"
 

--- a/tests/integrations/setfit/test_setfit.py
+++ b/tests/integrations/setfit/test_setfit.py
@@ -1,0 +1,87 @@
+from typing import Callable, Generator
+from unittest.mock import MagicMock, patch
+
+from datasets import Dataset
+from setfit import SetFitModel, SetFitTrainer
+
+import dataquality as dq
+from dataquality.clients.api import ApiClient
+from dataquality.integrations.setfit import watch
+from dataquality.schemas.task_type import TaskType
+from dataquality.utils.thread_pool import ThreadPoolManager
+from tests.conftest import DEFAULT_PROJECT_ID, DEFAULT_RUN_ID, LOCAL_MODEL_PATH
+
+dataset = Dataset.from_dict(
+    {"text": ["hello", "world", "foo", "bar"], "label": [0, 1] * 2}
+)
+model = SetFitModel.from_pretrained(LOCAL_MODEL_PATH)
+
+trainer = SetFitTrainer(
+    model=model,
+    train_dataset=dataset,
+    num_iterations=1,
+    column_mapping={"text": "text", "label": "label"},
+)
+trainer.train()
+
+
+@patch.object(ApiClient, "valid_current_user", return_value=True)
+@patch.object(dq.core.finish, "_version_check")
+@patch.object(dq.core.finish, "_reset_run")
+@patch.object(dq.core.finish, "upload_dq_log_file")
+@patch.object(ApiClient, "make_request")
+@patch.object(dq.core.finish, "wait_for_run")
+@patch.object(ApiClient, "get_project_by_name")
+@patch.object(ApiClient, "create_project")
+@patch.object(ApiClient, "get_project_run_by_name", return_value={})
+@patch.object(ApiClient, "create_run")
+@patch("dataquality.core.init._check_dq_version")
+@patch.object(
+    dq.clients.api.ApiClient,
+    "get_healthcheck_dq",
+    return_value={
+        "bucket_names": {
+            "images": "galileo-images",
+            "results": "galileo-project-runs-results",
+            "root": "galileo-project-runs",
+        },
+        "minio_fqdn": "127.0.0.1:9000",
+    },
+)
+@patch.object(dq.core.init.ApiClient, "valid_current_user", return_value=True)
+def test_auto(
+    mock_valid_user: MagicMock,
+    mock_dq_healthcheck: MagicMock,
+    mock_check_dq_version: MagicMock,
+    mock_create_run: MagicMock,
+    mock_get_project_run_by_name: MagicMock,
+    mock_create_project: MagicMock,
+    mock_get_project_by_name: MagicMock,
+    set_test_config: Callable,
+    mock_wait_for_run: MagicMock,
+    mock_make_request: MagicMock,
+    mock_upload_log_file: MagicMock,
+    mock_reset_run: MagicMock,
+    mock_version_check: MagicMock,
+    cleanup_after_use: Generator,
+) -> None:
+    global dataset
+    mock_get_project_by_name.return_value = {"id": DEFAULT_PROJECT_ID}
+    mock_create_run.return_value = {"id": DEFAULT_RUN_ID}
+    set_test_config(current_project_id=None, current_run_id=None)
+
+    dq.init(task_type=TaskType.text_classification)
+    labels = ["nocat", "cat"]
+    dq.set_labels_for_run(labels)
+    split = "training"
+    batch_size = 3
+    ds_len = len(dataset)
+    dq_evaluate = watch(model)
+    dataset = dataset.map(lambda x, idx: {"id": idx}, with_indices=True)
+    for i in range(0, ds_len, batch_size):
+        print("batch", i)
+        batch = dataset[i : i + batch_size]
+        dq_evaluate(batch, split=split)
+
+    dq.finish()
+    ThreadPoolManager.wait_for_threads()


### PR DESCRIPTION
Due to recent demand, I have converted the notebook to support setfit in the following way:
```python
from dataquality.integrations.setfit import watch

dq.init(task_type=TaskType.text_classification)
labels = ["nocat", "cat"]
dq.set_labels_for_run(labels)
split = "training"
batch_size = 3
ds_len = len(dataset)
dq_evaluate = watch(model)
dataset = dataset.map(lambda x, idx: {"id": idx}, with_indices=True)
for i in range(0, ds_len, batch_size):
    print("batch", i)
    batch = dataset[i : i + batch_size]
    dq_evaluate(batch, split=split)

dq.finish()
```

[Issue in setfit repo](https://github.com/huggingface/setfit/issues/356)