### PR TITLE
Fix polygon id for image and remove nested pixels

### DIFF
--- a/dataquality/loggers/model_logger/semantic_segmentation.py
+++ b/dataquality/loggers/model_logger/semantic_segmentation.py
@@ -129,7 +129,9 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
         )
 
         # Image masks
-        pred_polygons_batch, gt_polygons_batch = find_polygons_batch(self.pred_masks, self.gt_masks)
+        pred_polygons_batch, gt_polygons_batch = find_polygons_batch(
+            self.pred_masks, self.gt_masks
+        )
         # Errors
         calculate_misclassified_polygons_batch(self.pred_masks, gt_polygons_batch)
         calculate_undetected_polygons_batch(self.pred_masks, gt_polygons_batch)

--- a/dataquality/loggers/model_logger/semantic_segmentation.py
+++ b/dataquality/loggers/model_logger/semantic_segmentation.py
@@ -129,8 +129,7 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
         )
 
         # Image masks
-        pred_polygons_batch = find_polygons_batch(self.pred_masks)
-        gt_polygons_batch = find_polygons_batch(self.gt_masks)
+        pred_polygons_batch, gt_polygons_batch = find_polygons_batch(self.pred_masks, self.gt_masks)
         # Errors
         calculate_misclassified_polygons_batch(self.pred_masks, gt_polygons_batch)
         calculate_undetected_polygons_batch(self.pred_masks, gt_polygons_batch)

--- a/dataquality/schemas/semantic_segmentation.py
+++ b/dataquality/schemas/semantic_segmentation.py
@@ -24,7 +24,7 @@ class Pixel(BaseModel):
     x: int
     y: int
 
-    def deserialize(self) -> List[List[int]]:
+    def deserialize_opencv(self) -> List[List[int]]:
         """Takes a pixel object and returns JSON compatible list
 
         We deserialize to a JSON compatible format that matches what OpenCV
@@ -33,6 +33,10 @@ class Pixel(BaseModel):
         OpenCV expects a list of list of pixel coordinates.
         """
         return [[self.x, self.y]]
+
+    def deserialize_json(self) -> List[int]:
+        """Takes a pixel object and returns JSON compatible list"""
+        return [self.x, self.y]
 
 
 class Contour(BaseModel):
@@ -60,7 +64,7 @@ class Polygon(BaseModel):
         """
         contours = []
         for contour in self.contours:
-            pixels = [pixel.deserialize() for pixel in contour.pixels]
+            pixels = [pixel.deserialize_opencv() for pixel in contour.pixels]
             contours.append(np.array(pixels))
         return contours
 
@@ -79,8 +83,8 @@ class Polygon(BaseModel):
         """
         contours = []
         for contour in self.contours:
-            pixels = [pixel.deserialize() for pixel in contour.pixels]
-            contours.append([pixels])
+            pixels = [pixel.deserialize_json() for pixel in contour.pixels]
+            contours.append(pixels)
 
         return {
             "id": self.id,

--- a/dataquality/utils/semantic_segmentation/polygons.py
+++ b/dataquality/utils/semantic_segmentation/polygons.py
@@ -14,7 +14,7 @@ from dataquality.schemas.semantic_segmentation import Contour, Pixel, Polygon
 object_store = ObjectStore()
 
 
-def find_polygons_batch(masks: torch.Tensor) -> List[List[Polygon]]:
+def find_polygons_batch(pred_masks: torch.Tensor, gt_masks: torch.Tensor) -> List[List[Polygon]]:
     """Creates polygons for a given batch
 
     NOTE: Background pixels do not get polygons
@@ -23,21 +23,27 @@ def find_polygons_batch(masks: torch.Tensor) -> List[List[Polygon]]:
         masks: Tensor of ground truth or predicted masks
             torch.Tensor of shape (batch_size, height, width)
 
-    Returns:
-        One List of mask polygons for each image in the batch
+    Returns (Tuple):
+        List of pred polygons for each image in the batch
+        List of ground truth polygons for each image in the batch
     """
-    masks_np = masks.numpy()
-    bs = masks_np.shape[0]
-    polygons_batch = []
+    pred_masks_np = pred_masks.numpy()
+    bs = pred_masks_np.shape[0]
+    gt_masks_np = gt_masks.numpy()
+
+    pred_polygons_batch = []
+    gt_polygons_batch = []
 
     for i in range(bs):
-        mask = masks_np[i]
-        polygons_batch.append(build_polygons_image(mask))
+        pred_polygons = build_polygons_image(pred_masks_np[i])
+        pred_polygons_batch.append(pred_polygons)
+        gt_polygons = build_polygons_image(gt_masks_np[i], len(pred_polygons))
+        polygons_batch.append(gt_polygons)
 
-    return polygons_batch
+    return pred_polygons_batch, gt_polygons_batch
 
 
-def build_polygons_image(mask: np.ndarray) -> List[Polygon]:
+def build_polygons_image(mask: np.ndarray, polygon_idx: int = 0) -> List[Polygon]:
     """Returns a list of Polygons for the mask of a single image
 
     Args:
@@ -60,7 +66,7 @@ def build_polygons_image(mask: np.ndarray) -> List[Polygon]:
             class_mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE
         )
 
-        polygons_per_label = build_polygons_label(contours, hierarchy, label_idx)
+        polygons_per_label = build_polygons_label(contours, hierarchy, label_idx, polygon_idx)
         polygons.extend(polygons_per_label)
 
     return polygons

--- a/dataquality/utils/semantic_segmentation/polygons.py
+++ b/dataquality/utils/semantic_segmentation/polygons.py
@@ -14,7 +14,9 @@ from dataquality.schemas.semantic_segmentation import Contour, Pixel, Polygon
 object_store = ObjectStore()
 
 
-def find_polygons_batch(pred_masks: torch.Tensor, gt_masks: torch.Tensor) -> List[List[Polygon]]:
+def find_polygons_batch(
+    pred_masks: torch.Tensor, gt_masks: torch.Tensor
+) -> Tuple[List, List]:
     """Creates polygons for a given batch
 
     NOTE: Background pixels do not get polygons
@@ -38,7 +40,7 @@ def find_polygons_batch(pred_masks: torch.Tensor, gt_masks: torch.Tensor) -> Lis
         pred_polygons = build_polygons_image(pred_masks_np[i])
         pred_polygons_batch.append(pred_polygons)
         gt_polygons = build_polygons_image(gt_masks_np[i], len(pred_polygons))
-        polygons_batch.append(gt_polygons)
+        gt_polygons_batch.append(gt_polygons)
 
     return pred_polygons_batch, gt_polygons_batch
 
@@ -66,7 +68,9 @@ def build_polygons_image(mask: np.ndarray, polygon_idx: int = 0) -> List[Polygon
             class_mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE
         )
 
-        polygons_per_label = build_polygons_label(contours, hierarchy, label_idx, polygon_idx)
+        polygons_per_label = build_polygons_label(
+            contours, hierarchy, label_idx, polygon_idx
+        )
         polygons.extend(polygons_per_label)
 
     return polygons


### PR DESCRIPTION
Removes unneeded nesting in Polygons. Now that Rodrigo is drawing polygons on his own without OpenCV, let's remove the nesting and have the polygon json saved in a more intuitive format.

We also want polygon ids to be 0 indexed per image, not per (gt image vs. pred image)