### PR TITLE
Bug/extra inference labels validation

### DIFF
--- a/dataquality/clients/api.py
+++ b/dataquality/clients/api.py
@@ -283,9 +283,7 @@ class ApiClient:
         project, run = self._get_project_run_id(
             project_name=project_name, run_name=run_name
         )
-        task_type = self.get_task_type(project, run)
-        labels = Route.ner_labels if task_type == TaskType.text_ner else Route.labels
-        url = f"{config.api_url}/{Route.content_path(project, run)}/{labels}"
+        url = f"{config.api_url}/{Route.content_path(project, run)}/{Route.labels}"
         params = {"task": task} if task else None
         res = self.make_request(RequestType.GET, url=url, params=params)
         return res["labels"]

--- a/dataquality/core/init.py
+++ b/dataquality/core/init.py
@@ -104,8 +104,8 @@ def _set_labels_for_existing_run(project_name: str, run_name: str) -> None:
         dataquality.set_labels_for_run(labels)
         dataquality.get_data_logger().logger_config.existing_run = True
         print(
-            f"🚀 Found existing run labels. Setting labels for run to {labels}. Do not "
-            f"set labels for this run."
+            f"🚀 Found existing run labels. Setting labels for run to {labels}. You do "
+            f"not need to set labels for this run."
         )
     # We except all Exceptions here because this should _never_ prohibit the user from
     # creating a new run.

--- a/dataquality/core/init.py
+++ b/dataquality/core/init.py
@@ -88,6 +88,22 @@ class InitManager:
             if not os.path.exists(out_dir):
                 os.makedirs(out_dir)
 
+def _set_labels_for_existing_run(project_name: str, run_name: str) -> None:
+    """When a run already exists, fetch and set the labels automatically
+
+    When users call `dq.init` with a project/run that already exists (for example,
+    to run inference), we want to fetch their labels for them and set them as a
+    convenience.
+
+    We also set the `existing_run` attribute to be True, so they cannot change their
+    labels. Their inference labels must match their train/test/val split labels
+    """
+    pass
+    # try:
+    #     labels = dataquality.metrics.get_labels_for_run(project_name, run_name)
+    #     dataquality.set_labels_for_run(labels)
+    #     dataquality.get_data_logger().logger_config.existing_run = True
+    # except
 
 @check_noop
 def init(
@@ -145,6 +161,7 @@ def init(
     run, run_created = _init.get_or_create_run(project_name, run_name, task_type)
 
     if not run_created:
+        _set_labels_for_existing_run(project_name, run_name, task_type)
         warnings.warn(
             f"Run: {project_name}/{run_name} already exists! "
             "The existing run will get overwritten on call to finish()!",

--- a/dataquality/core/init.py
+++ b/dataquality/core/init.py
@@ -222,4 +222,4 @@ def delete_run(project_name: str, run_name: str) -> None:
     """Deletes a run from Galileo"""
     pid, rid = api_client._get_project_run_id(project_name, run_name)
     api_client.delete_run(pid, rid)
-    print(f"🗑 Run {project_name}/{run_name} deleted")
+    print(f"🗑 Run {run_name} in project {project_name} deleted.")

--- a/dataquality/core/init.py
+++ b/dataquality/core/init.py
@@ -88,6 +88,7 @@ class InitManager:
             if not os.path.exists(out_dir):
                 os.makedirs(out_dir)
 
+
 def _set_labels_for_existing_run(project_name: str, run_name: str) -> None:
     """When a run already exists, fetch and set the labels automatically
 
@@ -98,12 +99,19 @@ def _set_labels_for_existing_run(project_name: str, run_name: str) -> None:
     We also set the `existing_run` attribute to be True, so they cannot change their
     labels. Their inference labels must match their train/test/val split labels
     """
-    pass
-    # try:
-    #     labels = dataquality.metrics.get_labels_for_run(project_name, run_name)
-    #     dataquality.set_labels_for_run(labels)
-    #     dataquality.get_data_logger().logger_config.existing_run = True
-    # except
+    try:
+        labels = dataquality.metrics.get_labels_for_run(project_name, run_name)
+        dataquality.set_labels_for_run(labels)
+        dataquality.get_data_logger().logger_config.existing_run = True
+        print(
+            f"🚀 Found existing run labels. Setting labels for run to {labels}. Do not "
+            f"set labels for this run."
+        )
+    # We except all Exceptions here because this should _never_ prohibit the user from
+    # creating a new run.
+    except Exception:
+        return
+
 
 @check_noop
 def init(
@@ -159,9 +167,7 @@ def init(
 
     project, proj_created = _init.get_or_create_project(project_name, is_public)
     run, run_created = _init.get_or_create_run(project_name, run_name, task_type)
-
     if not run_created:
-        _set_labels_for_existing_run(project_name, run_name, task_type)
         warnings.warn(
             f"Run: {project_name}/{run_name} already exists! "
             "The existing run will get overwritten on call to finish()!",
@@ -208,3 +214,12 @@ def init(
         )
     # Reset all config variables
     dataquality.get_data_logger().logger_config.reset(factory=True)
+    if not run_created:
+        _set_labels_for_existing_run(project_name, run_name)
+
+
+def delete_run(project_name: str, run_name: str) -> None:
+    """Deletes a run from Galileo"""
+    pid, rid = api_client._get_project_run_id(project_name, run_name)
+    api_client.delete_run(pid, rid)
+    print(f"🗑 Run {project_name}/{run_name} deleted")

--- a/dataquality/core/log.py
+++ b/dataquality/core/log.py
@@ -461,8 +461,15 @@ def set_labels_for_run(labels: Union[List[List[str]], List[str]]) -> None:
     In the multi-label case, the outer order (order of the tasks) must match the
     task-order of the task-probabilities logged as well.
     """
+    if get_data_logger().logger_config.existing_run:
+        if labels != get_data_logger().logger_config.labels:
+            raise GalileoException(
+                "This run already has data logged to Galileo, and labels have been "
+                "set. You cannot change the labels of an existing run. If you need new "
+                "labels, delete this run (dq.delete_run()) or use a new run name. "
+                f"Current labels: {get_data_logger().logger_config.labels}"
+            )
     a.log_function("dq/set_labels_for_run")
-
     if isinstance(labels[0], (int, np.integer)):
         get_data_logger().logger_config.int_labels = True
     get_data_logger().logger_config.labels = labels

--- a/dataquality/loggers/data_logger/object_detection.py
+++ b/dataquality/loggers/data_logger/object_detection.py
@@ -92,8 +92,6 @@ class ObjectDetectionDataLogger(BaseGalileoDataLogger):
             width=self.width,
             height=self.height,
             **self.meta,
-            # bbox=self.bbox,
-            # cls=self.cls,
         )
         if self.split == Split.inference:
             inp["inference_name"] = [self.inference_name] * df_len

--- a/dataquality/loggers/logger_config/base_logger_config.py
+++ b/dataquality/loggers/logger_config/base_logger_config.py
@@ -34,6 +34,8 @@ class BaseLoggerConfig(BaseModel):
     feature_names: List[str] = []
     metadata_documents: Set = set()  # A document is a large str > 1k chars < 10k chars
     finish: Callable = lambda: None  # Overwritten in Semantic Segmentation
+    # True when calling `init` with a run that already exists
+    existing_run: bool = False
 
     class Config:
         validate_assignment = True

--- a/dataquality/metrics.py
+++ b/dataquality/metrics.py
@@ -661,7 +661,18 @@ def get_labels_for_run(
 
     If multi-label, and a task is provided, this will get the labels for that task.
     Otherwise, it will get all task-labels
+
+    In NER, the full label set with the tags for each label will be returned
     """
+    project_id, run_id = api_client._get_project_run_id(project_name, run_name)
+    task_type = api_client.get_task_type(project_id, run_id)
+    if task_type == TaskType.text_ner:
+        labels_object = f"{project_id}/{run_id}/ner_labels/ner_labels.json"
+        labels_path = object_store.download_file(
+            labels_object, "/tmp/labels.json", config.results_bucket_name
+        )
+        with open(labels_path) as f:
+            return json.loads(f.read())
     return api_client.get_labels_for_run(project_name, run_name, task)
 
 

--- a/dataquality/schemas/route.py
+++ b/dataquality/schemas/route.py
@@ -28,7 +28,6 @@ class Route(str, Enum):
     presigned_url = "presigned_url"
     tasks = "tasks"
     labels = "labels"
-    ner_labels = "ner_labels"
     epochs = "epochs"
     summary = "insights/summary"
     groupby = "insights/groupby"

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -243,9 +243,11 @@ def test_init_existing_project_existing_run(
     assert config.current_run_id == DEFAULT_RUN_ID
     assert config.current_project_id == DEFAULT_PROJECT_ID
 
-    mock_get_project_by_name.assert_called_once_with(EXISTING_PROJECT)
+    # Called once to see if exists, called again to get the labels for the run
+    assert mock_get_project_run_by_name.call_count == 2
+    mock_get_project_by_name.assert_called_with(EXISTING_PROJECT)
     mock_create_project.assert_not_called()
-    mock_get_project_run_by_name.assert_called_once_with(EXISTING_PROJECT, EXISTING_RUN)
+    mock_get_project_run_by_name.assert_called_with(EXISTING_PROJECT, EXISTING_RUN)
     mock_create_run.assert_not_called()
 
 
@@ -351,7 +353,9 @@ def test_init_project_name_collision(
 
     assert mock_get_project_by_name.call_count == 3
     mock_create_project.assert_not_called()
-    mock_get_project_run_by_name.assert_called_once_with("race-condition-proj", ANY)
+    # Called once to see if exists, called again to get the labels for the run
+    assert mock_get_project_run_by_name.call_count == 2
+    mock_get_project_run_by_name.assert_called_with("race-condition-proj", ANY)
     mock_create_run.assert_not_called()
 
 

--- a/tests/core/test_log.py
+++ b/tests/core/test_log.py
@@ -1,0 +1,24 @@
+from collections import Callable
+
+import pytest
+
+import dataquality as dq
+from dataquality.exceptions import GalileoException
+from dataquality.loggers.logger_config.text_classification import (
+    text_classification_logger_config as logger_config,
+)
+
+
+def test_set_labels_existing_run_different_labels(set_test_config: Callable):
+    logger_config.existing_run = True
+    logger_config.labels = ["A", "B", "C"]
+    with pytest.raises(GalileoException) as e:
+        dq.set_labels_for_run(["A", "B"])
+    assert str(e.value).startswith("This run already has data logged to Galileo")
+
+
+def test_set_labels_existing_run_same_labels(set_test_config: Callable):
+    logger_config.existing_run = True
+    logger_config.labels = ["A", "B", "C"]
+    dq.set_labels_for_run(["A", "B", "C"])
+    assert logger_config.labels == ["A", "B", "C"]


### PR DESCRIPTION
When someone trains a model, logging data to galileo, we validate that the shape of their labels matches the shape of their logits (for indexing and such).

BUT, if the user comes back the next day and does an inference run over that same run, but with new labels, and new logits, we don't validate that it matches the existing training data logged. This is problematic and will break things in the API. 

This addresses that problem

![image](https://github.com/rungalileo/dataquality/assets/22605641/d58d0d87-902d-42c2-a73b-fdd27f60fbad)
