### PR TITLE
truly random names using uuid

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -30,7 +30,7 @@ If you want to train without a model, you can use the auto framework:
         dataquality.get_insights()
 """
 
-__version__ = "v0.8.39"
+__version__ = "v0.8.40"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/utils/name.py
+++ b/dataquality/utils/name.py
@@ -1,6 +1,7 @@
 import random
 import re
 from typing import Optional
+from uuid import uuid4
 
 from dataquality.exceptions import GalileoException
 
@@ -1610,8 +1611,10 @@ COLORS = [
 
 
 def random_name() -> str:
-    result = []
-    result.append(random.choice(ADJECTIVES))
-    result.append(random.choice(COLORS))
-    result.append(random.choice(ANIMALS))
+    result = [
+        str(uuid4())[:5],
+        random.choice(ADJECTIVES),
+        random.choice(COLORS),
+        random.choice(ANIMALS),
+    ]
     return "_".join(result).lower()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ requires = [
     "numpy<1.24.0",
     "tenacity>=8.1.0",
     "evaluate",
+    "accelerate",
 ]
 
 [tool.flit.scripts]

--- a/tests/utils/test_name.py
+++ b/tests/utils/test_name.py
@@ -72,3 +72,4 @@ def test_name_random_seed() -> None:
     for _ in range(5):
         random.seed(0)
         names.append(random_name())
+    assert len(set(names)) == len(names)

--- a/tests/utils/test_name.py
+++ b/tests/utils/test_name.py
@@ -66,10 +66,11 @@ def test_name() -> None:
     assert anm in ANIMALS
 
 
-def test_name_random_seed() -> None:
+@pytest.mark.parametrize("seed", [0, 4, 12, 535, 42])
+def test_name_random_seed(seed: int) -> None:
     """Setting a seed should still let us have random names"""
     names = []
     for _ in range(5):
-        random.seed(0)
+        random.seed(seed)
         names.append(random_name())
     assert len(set(names)) == len(names)

--- a/tests/utils/test_name.py
+++ b/tests/utils/test_name.py
@@ -60,7 +60,7 @@ def test_validate_name_missing_name() -> None:
 
 
 def test_name() -> None:
-    adj, c, anm = random_name().split("_")
+    _, adj, c, anm = random_name().split("_")
     assert adj in ADJECTIVES
     assert c in COLORS
     assert anm in ANIMALS

--- a/tests/utils/test_name.py
+++ b/tests/utils/test_name.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 
 from dataquality.exceptions import GalileoException
@@ -62,3 +64,11 @@ def test_name() -> None:
     assert adj in ADJECTIVES
     assert c in COLORS
     assert anm in ANIMALS
+
+
+def test_name_random_seed() -> None:
+    """Setting a seed should still let us have random names"""
+    names = []
+    for _ in range(5):
+        random.seed(0)
+        names.append(random_name())


### PR DESCRIPTION
customers pointed out that sometimes the random names were being repeated. This happened because they were setting seeds in their code, which would cause the random generator to reset and return the same name.

UUIDs are not affected by the seed in the same way (tbh not sure how thats possible), but this prevents the issue from occuring. We tac on 5 characters from a uuid to make sure the name is random in the case of a seed being set