### PR TITLE
nicer naming system for runs

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -30,7 +30,7 @@ If you want to train without a model, you can use the auto framework:
         dataquality.get_insights()
 """
 
-__version__ = "v0.8.41"
+__version__ = "v0.8.42"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/clients/api.py
+++ b/dataquality/clients/api.py
@@ -332,6 +332,7 @@ class ApiClient:
         project_name: Optional[str] = None,
         run_name: Optional[str] = None,
         labels: Optional[Union[List, List[List]]] = None,
+        xray: bool = False,
     ) -> Dict:
         """Reinitiate a project/run that has already been finished
 
@@ -387,7 +388,7 @@ class ApiClient:
             labels=labels,
             tasks=tasks or None,
             task_type=task_type,
-            xray=False,  # Don't recalculate XRay in process
+            xray=xray,
         )
         res = self.make_request(
             RequestType.POST, url=f"{config.api_url}/{Route.jobs}", body=body

--- a/dataquality/core/init.py
+++ b/dataquality/core/init.py
@@ -122,11 +122,11 @@ def create_run_name(project_name: str) -> str:
     this project with this scheme.
 
     ie:
-        2023-05-15-1
-        2023-05-15-2
-        2023-05-15-3
+        2023-05-15_1
+        2023-05-15_2
+        2023-05-15_3
         ...
-        2023-05-15-n
+        2023-05-15_n
     """
     pid = api_client.get_project_by_name(project_name)["id"]
     runs = api_client.get_project_runs(pid)

--- a/dataquality/core/init.py
+++ b/dataquality/core/init.py
@@ -136,12 +136,12 @@ def create_run_name(project_name: str) -> str:
         # If it's not an auto-created run name, skip
         if today not in run["name"]:
             continue
-        splitter = f"{today}-"
+        splitter = f"{today}_"
         run_num = run["name"].split(splitter)[-1]
         if run_num.isdigit() and int(run_num) > max_run_today:
             max_run_today = int(run_num)
     run_num = max_run_today + 1
-    return f"{today}-{run_num}"
+    return f"{today}_{run_num}"
 
 
 @check_noop
@@ -194,11 +194,11 @@ def init(
         return
 
     project_name = validate_name(project_name, assign_random=True)
+    project, proj_created = _init.get_or_create_project(project_name, is_public)
+
     if not run_name:
         run_name = create_run_name(project_name)
     run_name = validate_name(run_name, assign_random=False)
-
-    project, proj_created = _init.get_or_create_project(project_name, is_public)
     run, run_created = _init.get_or_create_run(project_name, run_name, task_type)
     if not run_created:
         warnings.warn(

--- a/dataquality/core/init.py
+++ b/dataquality/core/init.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import warnings
+from datetime import datetime
 from typing import Dict, Optional, Tuple
 
 from pydantic.types import UUID4
@@ -113,6 +114,36 @@ def _set_labels_for_existing_run(project_name: str, run_name: str) -> None:
         return
 
 
+def create_run_name(project_name: str) -> str:
+    """Creates an auto-incrementing run_name for a given project
+
+    If a run_name is not passed into `init`, we create a run_name base with today's
+    date, and increment the digit at the end based on how many runs were created in
+    this project with this scheme.
+
+    ie:
+        2023-05-15-1
+        2023-05-15-2
+        2023-05-15-3
+        ...
+        2023-05-15-n
+    """
+    pid = api_client.get_project_by_name(project_name)["id"]
+    runs = api_client.get_project_runs(pid)
+    today = datetime.today().strftime("%Y-%m-%d")
+    max_run_today = 0
+    for run in runs:
+        # If it's not an auto-created run name, skip
+        if today not in run["name"]:
+            continue
+        splitter = f"{today}-"
+        run_num = run["name"].split(splitter)[-1]
+        if run_num.isdigit() and int(run_num) > max_run_today:
+            max_run_today = int(run_num)
+    run_num = max_run_today + 1
+    return f"{today}-{run_num}"
+
+
 @check_noop
 def init(
     task_type: str,
@@ -163,7 +194,9 @@ def init(
         return
 
     project_name = validate_name(project_name, assign_random=True)
-    run_name = validate_name(run_name, assign_random=True)
+    if not run_name:
+        run_name = create_run_name(project_name)
+    run_name = validate_name(run_name, assign_random=False)
 
     project, proj_created = _init.get_or_create_project(project_name, is_public)
     run, run_created = _init.get_or_create_run(project_name, run_name, task_type)

--- a/dataquality/utils/name.py
+++ b/dataquality/utils/name.py
@@ -1612,9 +1612,9 @@ COLORS = [
 
 def random_name() -> str:
     result = [
-        str(uuid4())[:5],
         random.choice(ADJECTIVES),
         random.choice(COLORS),
         random.choice(ANIMALS),
+        str(uuid4())[:5],
     ]
     return "_".join(result).lower()

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -666,14 +666,14 @@ def test_set_console_url_overwrites_with_param(mock_login: MagicMock) -> None:
     dataquality.core.init.ApiClient,
     "get_project_runs",
     return_value=[
-        {"name": f"{datetime.today().strftime('%Y-%m-%d')}-1"},
-        {"name": f"{datetime.today().strftime('%Y-%m-%d')}-2"},
-        {"name": f"{datetime.today().strftime('%Y-%m-%d')}-4"},
-        {"name": f"{datetime.today().strftime('%Y-%m-%d')}-6"},
+        {"name": f"{datetime.today().strftime('%Y-%m-%d')}_1"},
+        {"name": f"{datetime.today().strftime('%Y-%m-%d')}_2"},
+        {"name": f"{datetime.today().strftime('%Y-%m-%d')}_4"},
+        {"name": f"{datetime.today().strftime('%Y-%m-%d')}_6"},
     ],
 )
 def test_create_run_name(mock_get_runs: MagicMock, mock_get_p_name: MagicMock) -> None:
-    assert create_run_name("foo") == f"{datetime.today().strftime('%Y-%m-%d')}-7"
+    assert create_run_name("foo") == f"{datetime.today().strftime('%Y-%m-%d')}_7"
 
 
 @patch.object(
@@ -685,13 +685,13 @@ def test_create_run_name(mock_get_runs: MagicMock, mock_get_p_name: MagicMock) -
     return_value=[
         {"name": f"asdfas"},
         {"name": f"foo2"},
-        {"name": f"mew_new_run-6"},
+        {"name": f"mew_new_run_6"},
     ],
 )
 def test_create_run_name_no_defaults(
     mock_get_runs: MagicMock, mock_get_p_name: MagicMock
 ) -> None:
-    assert create_run_name("foo") == f"{datetime.today().strftime('%Y-%m-%d')}-1"
+    assert create_run_name("foo") == f"{datetime.today().strftime('%Y-%m-%d')}_1"
 
 
 @patch.object(
@@ -701,4 +701,4 @@ def test_create_run_name_no_defaults(
 def test_create_run_name_no_runs(
     mock_get_runs: MagicMock, mock_get_p_name: MagicMock
 ) -> None:
-    assert create_run_name("foo") == f"{datetime.today().strftime('%Y-%m-%d')}-1"
+    assert create_run_name("foo") == f"{datetime.today().strftime('%Y-%m-%d')}_1"

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -1,7 +1,9 @@
 import os
+from datetime import datetime
 from functools import partial
 from typing import Callable
 from unittest.mock import ANY, MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from tenacity import RetryError
@@ -11,6 +13,7 @@ import dataquality as dq
 from dataquality import config
 from dataquality.clients.api import ApiClient
 from dataquality.core.auth import GALILEO_AUTH_METHOD
+from dataquality.core.init import create_run_name
 from dataquality.exceptions import GalileoException
 from dataquality.schemas.task_type import TaskType
 from tests.conftest import DEFAULT_PROJECT_ID, DEFAULT_RUN_ID
@@ -36,7 +39,9 @@ from tests.test_utils.mock_request import (
 @patch.object(ApiClient, "create_run")
 @patch("dataquality.core.init._check_dq_version")
 @patch.object(dataquality.core.init.ApiClient, "valid_current_user", return_value=True)
+@patch("dataquality.core.init.create_run_name", return_value="foo")
 def test_init(
+    mock_create_run_name: MagicMock,
     mock_valid_user: MagicMock,
     mock_check_dq_version: MagicMock,
     mock_create_run: MagicMock,
@@ -65,7 +70,9 @@ def test_init(
 @patch.object(ApiClient, "get_project_run_by_name")
 @patch("dataquality.core.init._check_dq_version")
 @patch.object(dataquality.core.init.ApiClient, "valid_current_user", return_value=True)
+@patch("dataquality.core.init.create_run_name", return_value="foo")
 def test_init_reset_logger_config(
+    mock_create_run_name: MagicMock,
     mock_valid_user: MagicMock,
     mock_check_dq_version: MagicMock,
     mock_get_project_run_by_name: MagicMock,
@@ -89,7 +96,9 @@ def test_init_reset_logger_config(
 @patch.object(ApiClient, "create_run")
 @patch("dataquality.core.init._check_dq_version")
 @patch.object(dataquality.core.init.ApiClient, "valid_current_user", return_value=True)
+@patch("dataquality.core.init.create_run_name", return_value="foo")
 def test_init_new_private_project(
+    mock_create_run_name: MagicMock,
     mock_valid_user: MagicMock,
     mock_check_dq_version: MagicMock,
     mock_create_run: MagicMock,
@@ -120,7 +129,9 @@ def test_init_new_private_project(
 @patch.object(ApiClient, "create_run")
 @patch("dataquality.core.init._check_dq_version")
 @patch.object(dataquality.core.init.ApiClient, "valid_current_user", return_value=True)
+@patch("dataquality.core.init.create_run_name", return_value="foo")
 def test_init_existing_project(
+    mock_create_run_name: MagicMock,
     mock_valid_user: MagicMock,
     mock_check_dq_version: MagicMock,
     mock_create_run: MagicMock,
@@ -152,7 +163,9 @@ def test_init_existing_project(
 @patch.object(ApiClient, "create_run")
 @patch("dataquality.core.init._check_dq_version")
 @patch.object(dataquality.core.init.ApiClient, "valid_current_user", return_value=True)
+@patch("dataquality.core.init.create_run_name", return_value="foo")
 def test_init_new_project(
+    mock_create_run_name: MagicMock,
     mock_valid_user: MagicMock,
     mock_check_dq_version: MagicMock,
     mock_create_run: MagicMock,
@@ -318,7 +331,9 @@ def test_init_only_run(
 @patch.object(ApiClient, "create_run")
 @patch("dataquality.core.init._check_dq_version")
 @patch.object(dataquality.core.init.ApiClient, "valid_current_user", return_value=True)
+@patch("dataquality.core.init.create_run_name", return_value="foo")
 def test_init_project_name_collision(
+    mock_create_run_name: MagicMock,
     mock_valid_user: MagicMock,
     mock_check_dq_version: MagicMock,
     mock_create_run: MagicMock,
@@ -365,7 +380,9 @@ def test_init_project_name_collision(
 @patch.object(ApiClient, "create_run")
 @patch("dataquality.core.init._check_dq_version")
 @patch.object(dataquality.core.init.ApiClient, "valid_current_user", return_value=True)
+@patch("dataquality.core.init.create_run_name", return_value="foo")
 def test_init_project_name_collision_fails(
+    mock_create_run_name: MagicMock,
     mock_valid_user: MagicMock,
     mock_check_dq_version: MagicMock,
     mock_create_run: MagicMock,
@@ -406,7 +423,9 @@ def test_init_failed_login(mock_login: MagicMock, set_test_config: Callable) -> 
 @patch.object(ApiClient, "create_run")
 @patch("dataquality.core.init._check_dq_version")
 @patch("dataquality.core.init.login", side_effect=mocked_login)
+@patch("dataquality.core.init.create_run_name", return_value="foo")
 def test_init_successful_login(
+    mock_create_run_name: MagicMock,
     mock_login: MagicMock,
     mock_check_dq_version: MagicMock,
     mock_create_run: MagicMock,
@@ -450,7 +469,9 @@ def test_init_expired_token_login(
     dataquality.core.init.ApiClient, "get_current_user", side_effect=GalileoException
 )
 @patch("dataquality.core.init.login", side_effect=mocked_login)
+@patch("dataquality.core.init.create_run_name", return_value="foo")
 def test_init_expired_token_login_full(
+    mock_create_run_name: MagicMock,
     mock_login: MagicMock,
     mock_current_user: MagicMock,
     mock_check_dq_version: MagicMock,
@@ -491,7 +512,9 @@ def test_init_invalid_user_login(
 @patch("dataquality.core.init._check_dq_version")
 @patch.object(dataquality.core.init.ApiClient, "valid_current_user", return_value=False)
 @patch("dataquality.core.init.login", side_effect=mocked_login)
+@patch("dataquality.core.init.create_run_name", return_value="foo")
 def test_init_invalid_user_login_full(
+    mock_create_run_name: MagicMock,
     mock_login: MagicMock,
     mock_valid_user: MagicMock,
     mock_check_dq_version: MagicMock,
@@ -634,3 +657,48 @@ def test_set_console_url_overwrites_with_param(mock_login: MagicMock) -> None:
     dataquality.set_console_url(console_url="https://console.newfake2.com")
     assert dataquality.config.api_url == config.api_url == "https://api.newfake2.com"
     mock_login.assert_not_called()
+
+
+@patch.object(
+    dataquality.core.init.ApiClient, "get_project_by_name", return_value={"id": uuid4()}
+)
+@patch.object(
+    dataquality.core.init.ApiClient,
+    "get_project_runs",
+    return_value=[
+        {"name": f"{datetime.today().strftime('%Y-%m-%d')}-1"},
+        {"name": f"{datetime.today().strftime('%Y-%m-%d')}-2"},
+        {"name": f"{datetime.today().strftime('%Y-%m-%d')}-4"},
+        {"name": f"{datetime.today().strftime('%Y-%m-%d')}-6"},
+    ],
+)
+def test_create_run_name(mock_get_runs: MagicMock, mock_get_p_name: MagicMock) -> None:
+    assert create_run_name("foo") == f"{datetime.today().strftime('%Y-%m-%d')}-7"
+
+
+@patch.object(
+    dataquality.core.init.ApiClient, "get_project_by_name", return_value={"id": uuid4()}
+)
+@patch.object(
+    dataquality.core.init.ApiClient,
+    "get_project_runs",
+    return_value=[
+        {"name": f"asdfas"},
+        {"name": f"foo2"},
+        {"name": f"mew_new_run-6"},
+    ],
+)
+def test_create_run_name_no_defaults(
+    mock_get_runs: MagicMock, mock_get_p_name: MagicMock
+) -> None:
+    assert create_run_name("foo") == f"{datetime.today().strftime('%Y-%m-%d')}-1"
+
+
+@patch.object(
+    dataquality.core.init.ApiClient, "get_project_by_name", return_value={"id": uuid4()}
+)
+@patch.object(dataquality.core.init.ApiClient, "get_project_runs", return_value=[])
+def test_create_run_name_no_runs(
+    mock_get_runs: MagicMock, mock_get_p_name: MagicMock
+) -> None:
+    assert create_run_name("foo") == f"{datetime.today().strftime('%Y-%m-%d')}-1"

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -683,9 +683,9 @@ def test_create_run_name(mock_get_runs: MagicMock, mock_get_p_name: MagicMock) -
     dataquality.core.init.ApiClient,
     "get_project_runs",
     return_value=[
-        {"name": f"asdfas"},
-        {"name": f"foo2"},
-        {"name": f"mew_new_run_6"},
+        {"name": "asdfas"},
+        {"name": "foo2"},
+        {"name": "mew_new_run_6"},
     ],
 )
 def test_create_run_name_no_defaults(

--- a/tests/utils/test_name.py
+++ b/tests/utils/test_name.py
@@ -60,7 +60,7 @@ def test_validate_name_missing_name() -> None:
 
 
 def test_name() -> None:
-    _, adj, c, anm = random_name().split("_")
+    adj, c, anm, _ = random_name().split("_")
     assert adj in ADJECTIVES
     assert c in COLORS
     assert anm in ANIMALS


### PR DESCRIPTION
the core of this pr is the new `create_run_name` function + tests for it. 

User feedback suggested a nicer naming system. Instead of random names that are hard to parse, create run names that are today's date followed by the run_number that was created today.

tested with pytest, as well as:
With a new project
![image](https://github.com/rungalileo/dataquality/assets/22605641/f092d681-07e9-4a5c-91fc-d6dadaa83178)



And an existing project
![image](https://github.com/rungalileo/dataquality/assets/22605641/817e5f6a-15ac-4278-bd83-5de0fa31f1de)

