### PR TITLE
Ultralytics: fix rel path issue during predict

### DIFF
--- a/dataquality/dqyolo.py
+++ b/dataquality/dqyolo.py
@@ -97,7 +97,7 @@ def main() -> None:
     for split in [Split.training, Split.validation, Split.test]:
         # Create a temporary config file for the training set that changes
         # the dataset path to the validation set so we can log the results
-        tmp_cfg_path = temporary_cfg_for_val(cfg, split)
+        tmp_cfg_path = temporary_cfg_for_val(cfg, split, dataset_path)
         if not tmp_cfg_path:
             continue
         relative_img_path = relative_img_paths[split]

--- a/dataquality/utils/ultralytics.py
+++ b/dataquality/utils/ultralytics.py
@@ -1,7 +1,7 @@
 import time
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, List, Optional, Tuple
-from pathlib import Path
 
 import cv2
 import numpy as np

--- a/dataquality/utils/ultralytics.py
+++ b/dataquality/utils/ultralytics.py
@@ -315,7 +315,7 @@ def temporary_cfg_for_val(cfg: Dict, split: Split, dataset_path: str) -> str:
         return ""
     new_value = cfg.get(ultralytics_split_mapping[split])
     for csplit in ["train", "val", "test"]:
-        cfg_copy[csplit] = str((Path(dataset_path) / Path(new_value)).resolve())
+        cfg_copy[csplit] = str((Path(dataset_path) / Path(str(new_value))).resolve())
     tmp = NamedTemporaryFile("w", delete=False, suffix=".yaml")
     yaml.safe_dump(cfg_copy, tmp)
     tmp.close()

--- a/dataquality/utils/ultralytics.py
+++ b/dataquality/utils/ultralytics.py
@@ -1,6 +1,7 @@
 import time
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, List, Optional, Tuple
+from pathlib import Path
 
 import cv2
 import numpy as np
@@ -300,17 +301,21 @@ def _read_config(path: str) -> Dict:
         return yaml.safe_load(file)
 
 
-def temporary_cfg_for_val(cfg: Dict, split: Split) -> str:
+def temporary_cfg_for_val(cfg: Dict, split: Split, dataset_path: str) -> str:
     """Creates a temporary config file with the split set to the given split.
+    We have to convert the paths to relative paths since the resulting yaml file
+    will be saved in a different location (and so relative paths stop making sense).
 
-    :param cfg_path: Path to the config file
-    :param split: Split to set the config to"""
+    :param cfg: config file
+    :param split: Split to set the config to
+    :param dataset_path: path to the config file
+    """
     cfg_copy = {**cfg}
     if not cfg.get(ultralytics_split_mapping[split]):
         return ""
     new_value = cfg.get(ultralytics_split_mapping[split])
     for csplit in ["train", "val", "test"]:
-        cfg_copy[csplit] = new_value
+        cfg_copy[csplit] = str((Path(dataset_path) / Path(new_value)).resolve())
     tmp = NamedTemporaryFile("w", delete=False, suffix=".yaml")
     yaml.safe_dump(cfg_copy, tmp)
     tmp.close()

--- a/tests/integrations/ultralytics/test_cv_yolo.py
+++ b/tests/integrations/ultralytics/test_cv_yolo.py
@@ -71,7 +71,7 @@ def test_end2end_yolov8(
     for split in [Split.training, Split.validation]:  # ,
         dq.set_split(split)
         cfg = _read_config(ds_path)
-        tmp_cfg_path = temporary_cfg_for_val(cfg, split)
+        tmp_cfg_path = temporary_cfg_for_val(cfg, split, ds_path)
         if not tmp_cfg_path:
             continue
         dq.set_epoch(0)


### PR DESCRIPTION
For ultralytics integration (Object Detection). 

When calling predict with relative paths in the data.YAML file, our `dqyolo` integration creates a temporary yaml file stored at a different location. The images rel paths don't make sense anymore, see below for example where yaml is saved in `/tmp`

![Screenshot 2023-05-18 at 2 21 54 PM](https://github.com/rungalileo/dataquality/assets/112427971/d5e63fb7-9155-41b0-a3d1-fe715db5cc0d)

We overwrite the rel paths with absolute paths. 
Tested all scenarios where yaml file is given as abs/rel path, path in yaml file is given as abs/rel path.