### PR TITLE
Chore/semseg chores

### DIFF
--- a/dataquality/integrations/cv/torch/semantic_segmentation.py
+++ b/dataquality/integrations/cv/torch/semantic_segmentation.py
@@ -376,6 +376,9 @@ class SemanticTorchLogger(TorchLogger):
             logger.log()
 
     def finish(self) -> None:
+        # call to eval to make sure we are not in train mode for batch norm
+        # in batch norm with 1 example can get an error if we are in train mode
+        self.model.eval()
         self.called_finish = True
         # finish function that runs our inference at the end of training
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -393,6 +396,7 @@ class SemanticTorchLogger(TorchLogger):
                 img = batch[self.image_col]
                 img = img.to(device)
                 self.model(img)
+        self.model.train()
 
 
 # store the batch

--- a/dataquality/integrations/cv/torch/semantic_segmentation.py
+++ b/dataquality/integrations/cv/torch/semantic_segmentation.py
@@ -371,6 +371,7 @@ class SemanticTorchLogger(TorchLogger):
                 ),  # Torch tensor (bs, w, h)
                 output_probs=probs,  # Torch tensor (bs, w, h, classes)
                 mislabeled_pixels=mislabeled_pixels,  # torch tensor (bs, w, h)
+                number_classes=self.number_classes,
             )
             logger.log()
 

--- a/dataquality/loggers/model_logger/base_model_logger.py
+++ b/dataquality/loggers/model_logger/base_model_logger.py
@@ -98,8 +98,7 @@ class BaseGalileoModelLogger(BaseGalileoLogger):
         # global variables (cur_split and cur_epoch) that are subject to change
         # between subsequent threads
         self.set_split_epoch()
-        # ThreadPoolManager.add_thread(target=self._add_threaded_log)
-        self._add_threaded_log()
+        ThreadPoolManager.add_thread(target=self._add_threaded_log)
 
     def write_model_output(self, data: Dict) -> None:
         """Creates an hdf5 file from the data dict"""

--- a/dataquality/loggers/model_logger/base_model_logger.py
+++ b/dataquality/loggers/model_logger/base_model_logger.py
@@ -17,6 +17,7 @@ from dataquality.schemas.task_type import TaskType
 from dataquality.utils.ampli import AmpliMetric
 from dataquality.utils.dq_logger import get_dq_logger
 from dataquality.utils.hdf5_store import _save_hdf5_file
+from dataquality.utils.thread_pool import ThreadPoolManager
 
 analytics = Analytics(ApiClient, config)  # type: ignore
 

--- a/dataquality/loggers/model_logger/base_model_logger.py
+++ b/dataquality/loggers/model_logger/base_model_logger.py
@@ -17,7 +17,6 @@ from dataquality.schemas.task_type import TaskType
 from dataquality.utils.ampli import AmpliMetric
 from dataquality.utils.dq_logger import get_dq_logger
 from dataquality.utils.hdf5_store import _save_hdf5_file
-from dataquality.utils.thread_pool import ThreadPoolManager
 
 analytics = Analytics(ApiClient, config)  # type: ignore
 
@@ -99,7 +98,8 @@ class BaseGalileoModelLogger(BaseGalileoLogger):
         # global variables (cur_split and cur_epoch) that are subject to change
         # between subsequent threads
         self.set_split_epoch()
-        ThreadPoolManager.add_thread(target=self._add_threaded_log)
+        # ThreadPoolManager.add_thread(target=self._add_threaded_log)
+        self._add_threaded_log()
 
     def write_model_output(self, data: Dict) -> None:
         """Creates an hdf5 file from the data dict"""

--- a/dataquality/loggers/model_logger/semantic_segmentation.py
+++ b/dataquality/loggers/model_logger/semantic_segmentation.py
@@ -219,7 +219,9 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
             self.pred_masks, self.gold_masks
         )
         # Errors
-        calculate_misclassified_polygons_batch(self.pred_masks, gold_polygons_batch)
+        calculate_misclassified_polygons_batch(
+            self.pred_masks, self.gold_masks, pred_polygons_batch, gold_polygons_batch
+        )
         calculate_missed_polygons_batch(self.pred_masks, gold_polygons_batch)
         calculate_ghost_polygons_batch(self.gold_masks, pred_polygons_batch)
         heights = [img.shape[-1] for img in self.gold_masks]

--- a/dataquality/loggers/model_logger/semantic_segmentation.py
+++ b/dataquality/loggers/model_logger/semantic_segmentation.py
@@ -138,6 +138,7 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
         accuracys = []
         misclassified_class = []
         misclassified_class_percent = []
+        ghost_polygons = []
         for i, image_id in enumerate(self.image_ids):
             pred_polygons = pred_polygons_batch[i]
             for polygon in pred_polygons:
@@ -151,6 +152,7 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
                 misclassified_class.append(polygon.misclassified_class.label)
                 misclassified_class_percent.append(polygon.misclassified_class.percent)
                 accuracys.append(polygon.accuracy)
+                ghost_polygons.append(polygon.ghost_percentage)
                 upload_polygon_contours(polygon, self.contours_path)
                 polygon_ids.append(polygon.uuid)
 
@@ -166,6 +168,7 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
                 misclassified_class.append(polygon.misclassified_class.label)
                 misclassified_class_percent.append(polygon.misclassified_class.percent)
                 accuracys.append(polygon.accuracy)
+                ghost_polygons.append(polygon.ghost_percentage)
                 upload_polygon_contours(polygon, self.contours_path)
                 polygon_ids.append(polygon.uuid)
 
@@ -180,6 +183,8 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
             "lm_percentage": lm_percentages,
             "misclassified_class": misclassified_class,
             "misclassified_class_percent": misclassified_class_percent,
+            "accuracy": accuracys,
+            "ghost": ghost_polygons,
             "split": [self.split] * len(image_ids),
             "is_pred": [False if i == -1 else True for i in preds],
             "is_gold": [False if i == -1 else True for i in golds],
@@ -221,7 +226,9 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
         heights = [img.shape[-1] for img in self.gold_masks]
         widths = [img.shape[-2] for img in self.gold_masks]
 
-        calculate_lm_polygons_batch(self.mislabled_pixels, gold_polygons_batch)
+        calculate_lm_polygons_batch(
+            self.mislabled_pixels, gold_polygons_batch, (heights[0], widths[0])
+        )
         calculate_dep_polygons_batch(
             gold_polygons_batch,
             dep_heatmaps.numpy(),

--- a/dataquality/loggers/model_logger/semantic_segmentation.py
+++ b/dataquality/loggers/model_logger/semantic_segmentation.py
@@ -14,8 +14,9 @@ from dataquality.schemas.split import Split
 from dataquality.utils.semantic_segmentation.errors import (
     calculate_dep_polygons_batch,
     calculate_ghost_polygons_batch,
+    calculate_lm_polygons_batch,
     calculate_misclassified_polygons_batch,
-    calculate_undetected_polygons_batch,
+    calculate_missed_polygons_batch,
 )
 from dataquality.utils.semantic_segmentation.lm import upload_mislabeled_pixels
 from dataquality.utils.semantic_segmentation.metrics import (
@@ -191,12 +192,14 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
             self.pred_masks, self.gold_masks
         )
         # Errors
+
         calculate_misclassified_polygons_batch(self.pred_masks, gold_polygons_batch)
-        calculate_undetected_polygons_batch(self.pred_masks, gold_polygons_batch)
+        calculate_missed_polygons_batch(self.pred_masks, gold_polygons_batch)
         calculate_ghost_polygons_batch(self.gold_masks, pred_polygons_batch)
         heights = [img.shape[-1] for img in self.gold_masks]
         widths = [img.shape[-2] for img in self.gold_masks]
 
+        calculate_lm_polygons_batch(self.mislabled_pixels, gold_polygons_batch)
         calculate_dep_polygons_batch(
             gold_polygons_batch,
             dep_heatmaps.numpy(),

--- a/dataquality/loggers/model_logger/semantic_segmentation.py
+++ b/dataquality/loggers/model_logger/semantic_segmentation.py
@@ -226,7 +226,10 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
         widths = [img.shape[-2] for img in self.gold_masks]
 
         calculate_lm_polygons_batch(
-            self.mislabled_pixels, gold_polygons_batch, (heights[0], widths[0])
+            self.mislabled_pixels,
+            gold_polygons_batch,
+            pred_polygons_batch,
+            (heights[0], widths[0]),
         )
         calculate_dep_polygons_batch(
             gold_polygons_batch,

--- a/dataquality/loggers/model_logger/semantic_segmentation.py
+++ b/dataquality/loggers/model_logger/semantic_segmentation.py
@@ -219,7 +219,6 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
             self.pred_masks, self.gold_masks
         )
         # Errors
-
         calculate_misclassified_polygons_batch(self.pred_masks, gold_polygons_batch)
         calculate_missed_polygons_batch(self.pred_masks, gold_polygons_batch)
         calculate_ghost_polygons_batch(self.gold_masks, pred_polygons_batch)

--- a/dataquality/loggers/model_logger/semantic_segmentation.py
+++ b/dataquality/loggers/model_logger/semantic_segmentation.py
@@ -133,6 +133,11 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
         golds = []
         data_error_potentials = []
         errors = []
+        missed_percentages = []
+        lm_percentages = []
+        accuracys = []
+        misclassified_class = []
+        misclassified_class_percent = []
         for i, image_id in enumerate(self.image_ids):
             pred_polygons = pred_polygons_batch[i]
             for polygon in pred_polygons:
@@ -141,8 +146,14 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
                 golds.append(-1)
                 data_error_potentials.append(polygon.data_error_potential)
                 errors.append(polygon.error_type.value)
+                missed_percentages.append(polygon.missed_percentage)
+                lm_percentages.append(polygon.lm_percentage)
+                misclassified_class.append(polygon.misclassified_class.label)
+                misclassified_class_percent.append(polygon.misclassified_class.percent)
+                accuracys.append(polygon.accuracy)
                 upload_polygon_contours(polygon, self.contours_path)
                 polygon_ids.append(polygon.uuid)
+
             gold_polygons = gold_polygons_batch[i]
             for polygon in gold_polygons:
                 image_ids.append(image_id)
@@ -150,6 +161,11 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
                 golds.append(polygon.label_idx)
                 data_error_potentials.append(polygon.data_error_potential)
                 errors.append(polygon.error_type.value)
+                missed_percentages.append(polygon.missed_percentage)
+                lm_percentages.append(polygon.lm_percentage)
+                misclassified_class.append(polygon.misclassified_class.label)
+                misclassified_class_percent.append(polygon.misclassified_class.percent)
+                accuracys.append(polygon.accuracy)
                 upload_polygon_contours(polygon, self.contours_path)
                 polygon_ids.append(polygon.uuid)
 
@@ -160,6 +176,10 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
             "gold": golds,
             "data_error_potential": data_error_potentials,
             "galileo_error_type": errors,
+            "missed_percentage": missed_percentages,
+            "lm_percentage": lm_percentages,
+            "misclassified_class": misclassified_class,
+            "misclassified_class_percent": misclassified_class_percent,
             "split": [self.split] * len(image_ids),
             "is_pred": [False if i == -1 else True for i in preds],
             "is_gold": [False if i == -1 else True for i in golds],

--- a/dataquality/schemas/semantic_segmentation.py
+++ b/dataquality/schemas/semantic_segmentation.py
@@ -55,8 +55,8 @@ class MisclassifiedClassLabel(BaseModel):
 class Polygon(BaseModel):
     uuid: str  # UUID4
     label_idx: int
-    lm_percentage: Optional[float] = 0.0
-    accuracy: Optional[float] = 0.0
+    lm_percentage: float = 0.0
+    accuracy: float = 0.0
     misclassified_class: MisclassifiedClassLabel = MisclassifiedClassLabel(
         label=-1, percent=0.0
     )

--- a/dataquality/schemas/semantic_segmentation.py
+++ b/dataquality/schemas/semantic_segmentation.py
@@ -57,12 +57,13 @@ class Polygon(BaseModel):
     label_idx: int
     lm_percentage: Optional[float] = 0.0
     accuracy: Optional[float] = 0.0
-    misclassified_class: Optional[
-        MisclassifiedClassLabel
-    ] = MisclassifiedClassLabel(label=-1, percent=0.0)
+    misclassified_class: MisclassifiedClassLabel = MisclassifiedClassLabel(
+        label=-1, percent=0.0
+    )
     missed_percentage: Optional[float] = 0.0
     error_type: ErrorType = ErrorType.none
     contours: List[Contour]
+    ghost_percentage: float = 0
     data_error_potential: Optional[float] = None
 
     @property

--- a/dataquality/schemas/semantic_segmentation.py
+++ b/dataquality/schemas/semantic_segmentation.py
@@ -47,10 +47,18 @@ class Contour(BaseModel):
     pixels: List[Pixel]
 
 
+class MisclassifiedClassLabel(BaseModel):
+    label: int
+    pct: float
+
+
 class Polygon(BaseModel):
     uuid: str  # UUID4
     label_idx: int
+    lm_percentage: Optional[float]
+    accuracy: Optional[float]
     misclassified_class_label: Optional[int] = None
+    missed_percentage: Optional[float]
     error_type: ErrorType = ErrorType.none
     contours: List[Contour]
     data_error_potential: Optional[float] = None

--- a/dataquality/schemas/semantic_segmentation.py
+++ b/dataquality/schemas/semantic_segmentation.py
@@ -18,6 +18,7 @@ class SemSegCols(str, Enum):
 class ErrorType(str, Enum):
     classification = "classification"
     undetected = "undetected"
+    ghost = "ghost"
     none = None
 
 

--- a/dataquality/schemas/semantic_segmentation.py
+++ b/dataquality/schemas/semantic_segmentation.py
@@ -55,6 +55,7 @@ class MisclassifiedClassLabel(BaseModel):
 class Polygon(BaseModel):
     uuid: str  # UUID4
     label_idx: int
+    area: Optional[int]
     lm_percentage: Optional[float]
     accuracy: Optional[float]
     misclassified_class: MisclassifiedClassLabel = MisclassifiedClassLabel(

--- a/dataquality/schemas/semantic_segmentation.py
+++ b/dataquality/schemas/semantic_segmentation.py
@@ -55,15 +55,15 @@ class MisclassifiedClassLabel(BaseModel):
 class Polygon(BaseModel):
     uuid: str  # UUID4
     label_idx: int
-    lm_percentage: float = 0.0
-    accuracy: float = 0.0
+    lm_percentage: Optional[float]
+    accuracy: Optional[float]
     misclassified_class: MisclassifiedClassLabel = MisclassifiedClassLabel(
         label=-1, percent=0.0
     )
-    missed_percentage: Optional[float] = 0.0
+    missed_percentage: float = 0.0
     error_type: ErrorType = ErrorType.none
     contours: List[Contour]
-    ghost_percentage: float = 0
+    ghost_percentage: float = 0.0
     data_error_potential: Optional[float] = None
 
     @property

--- a/dataquality/schemas/semantic_segmentation.py
+++ b/dataquality/schemas/semantic_segmentation.py
@@ -49,16 +49,18 @@ class Contour(BaseModel):
 
 class MisclassifiedClassLabel(BaseModel):
     label: int
-    pct: float
+    percent: float
 
 
 class Polygon(BaseModel):
     uuid: str  # UUID4
     label_idx: int
-    lm_percentage: Optional[float]
-    accuracy: Optional[float]
-    misclassified_class_label: Optional[int] = None
-    missed_percentage: Optional[float]
+    lm_percentage: Optional[float] = 0.0
+    accuracy: Optional[float] = 0.0
+    misclassified_class: Optional[
+        MisclassifiedClassLabel
+    ] = MisclassifiedClassLabel(label=-1, percent=0.0)
+    missed_percentage: Optional[float] = 0.0
     error_type: ErrorType = ErrorType.none
     contours: List[Contour]
     data_error_potential: Optional[float] = None

--- a/dataquality/utils/semantic_segmentation/errors.py
+++ b/dataquality/utils/semantic_segmentation/errors.py
@@ -96,9 +96,9 @@ def calculate_misclassified_polygons(
             pred_mask, out_polygon, polygon.label_idx
         )
         polygon.accuracy = accuracy
-        polygon.misclassified_class_label = MisclassifiedClassLabel(
+        polygon.misclassified_class = MisclassifiedClassLabel(
             label=misclassified_label[0],
-            pct=misclassified_label[1],
+            percent=misclassified_label[1],
         )
         if accuracy < MISCLASSIFIED_THRESHOLD:
             polygon.error_type = ErrorType.classification
@@ -318,4 +318,6 @@ def calculate_lm_polygon(
         float: percentage of mislabelled pixels in a polygon
     """
     relevant_region = polygon_img != 0
+    if relevant_region.sum() == 0:
+        return 0
     return (mislabelled_pixel_map != 0)[relevant_region].sum() / relevant_region.sum()

--- a/dataquality/utils/semantic_segmentation/errors.py
+++ b/dataquality/utils/semantic_segmentation/errors.py
@@ -103,7 +103,8 @@ def calculate_misclassified_polygons(
         )
         if accuracy < MISCLASSIFIED_THRESHOLD:
             polygon.error_type = ErrorType.classification
-            
+
+
 def calculate_pred_polygon_accuracy(
     gold_mask: torch.Tensor,
     pred_polygons: List[Polygon],
@@ -125,8 +126,8 @@ def calculate_pred_polygon_accuracy(
 def calculate_misclassified_polygons_batch(
     pred_masks: torch.Tensor,
     gold_masks: torch.Tensor,
-    gold_polygons_batch: List[List[Polygon]],
     pred_polygons_batch: List[List[Polygon]],
+    gold_polygons_batch: List[List[Polygon]],
 ) -> None:
     """Calculates a set of misclassified polygon ids from the
     predicted mask for each image in a batch
@@ -145,10 +146,9 @@ def calculate_misclassified_polygons_batch(
         pred_mask = pred_masks[idx].numpy()
         gold_mask = gold_masks[idx].numpy()
         pred_polygons = pred_polygons_batch[idx]
-        gold_polygons = gold_polygons_batch[idx]
+        gold_polygons_batch[idx]
         calculate_misclassified_polygons(pred_mask, pred_polygons)
         calculate_pred_polygon_accuracy(gold_mask, pred_polygons)
-
 
 
 def calculate_missed_percentage(preds: np.ndarray, gold_mask: np.ndarray) -> float:

--- a/dataquality/utils/semantic_segmentation/errors.py
+++ b/dataquality/utils/semantic_segmentation/errors.py
@@ -281,7 +281,8 @@ def calculate_amount_ghosted(polygon_im: np.ndarray, gold_mask: np.ndarray) -> f
 
 def calculate_lm_polygons_batch(
     mislabeled_pixels: torch.Tensor,
-    polygons_batch: List[List[Polygon]],
+    gold_polygons_batch: List[List[Polygon]],
+    pred_polygons_batch: List[List[Polygon]],
     shape: Tuple[int, int],
 ) -> None:
     """Calculate and attach the LM percentage per polygon in a batch
@@ -295,8 +296,10 @@ def calculate_lm_polygons_batch(
     for idx in range(len(mislabeled_pixels)):
         mislabeled_pixel_map = mislabeled_pixels[idx].numpy()
 
-        polygons = polygons_batch[idx]
-        calculate_lm_polygons(mislabeled_pixel_map, polygons)
+        gold_polygons = gold_polygons_batch[idx]
+        pred_polygons = pred_polygons_batch[idx]
+        calculate_lm_polygons(mislabeled_pixel_map, gold_polygons)
+        calculate_lm_polygons(mislabeled_pixel_map, pred_polygons)
 
 
 def calculate_lm_polygons(

--- a/dataquality/utils/semantic_segmentation/errors.py
+++ b/dataquality/utils/semantic_segmentation/errors.py
@@ -106,7 +106,7 @@ def calculate_misclassified_polygons(
 
 
 def calculate_pred_polygon_accuracy(
-    gold_mask: torch.Tensor,
+    gold_mask: np.ndarray,
     pred_polygons: List[Polygon],
 ) -> None:
     """calculate the pred polygon accuracy without the error type flag
@@ -146,8 +146,8 @@ def calculate_misclassified_polygons_batch(
         pred_mask = pred_masks[idx].numpy()
         gold_mask = gold_masks[idx].numpy()
         pred_polygons = pred_polygons_batch[idx]
-        gold_polygons_batch[idx]
-        calculate_misclassified_polygons(pred_mask, pred_polygons)
+        gold_polygons = gold_polygons_batch[idx]
+        calculate_misclassified_polygons(pred_mask, gold_polygons)
         calculate_pred_polygon_accuracy(gold_mask, pred_polygons)
 
 

--- a/dataquality/utils/semantic_segmentation/errors.py
+++ b/dataquality/utils/semantic_segmentation/errors.py
@@ -265,7 +265,7 @@ def calculate_ghost_polygons(
             polygon.error_type = ErrorType.ghost
 
 
-def calculate_amount_ghosted(polygon_im: np.ndarray, gold_mask: torch.Tensor) -> float:
+def calculate_amount_ghosted(polygon_im: np.ndarray, gold_mask: np.ndarray) -> float:
     """Calculates the amount of background in the gt of a polygon
 
     Args:
@@ -281,26 +281,26 @@ def calculate_amount_ghosted(polygon_im: np.ndarray, gold_mask: torch.Tensor) ->
 
 def calculate_lm_polygons_batch(
     mislabeled_pixels: torch.Tensor,
-    gold_polygons_batch: List[List[Polygon]],
+    polygons_batch: List[List[Polygon]],
     shape: Tuple[int, int],
 ) -> None:
     """Calculate and attach the LM percentage per polygon in a batch
 
     Args:
         mislabeled_pixels (torch.Tensor): map of bs, h, w of mislabled pixels
-        gold_polygons_batch (List[List[Polygon]]): gold polygons for each image
+        polygons_batch (List[List[Polygon]]): polygons for each image
         shape (Tuple[int, int]): shape of the image to be resized to
     """
     mislabeled_pixels = interpolate_lm_maps(mislabeled_pixels, shape)
     for idx in range(len(mislabeled_pixels)):
         mislabeled_pixel_map = mislabeled_pixels[idx].numpy()
 
-        gold_polygons = gold_polygons_batch[idx]
-        calculate_lm_polygons(mislabeled_pixel_map, gold_polygons)
+        polygons = polygons_batch[idx]
+        calculate_lm_polygons(mislabeled_pixel_map, polygons)
 
 
 def calculate_lm_polygons(
-    mislabelled_pixel_map: torch.Tensor, gold_polygons: List[Polygon]
+    mislabelled_pixel_map: torch.Tensor, polygons: List[Polygon]
 ) -> None:
     """Calculates and attaches the LM percentage to each polygon
 
@@ -308,7 +308,7 @@ def calculate_lm_polygons(
         mislabelled_pixel_map (torch.Tensor): map of bs, h, w of mislabled pixels
         gold_polygons (List[Polygon]): list of all gold polygons for an image
     """
-    for polygon in gold_polygons:
+    for polygon in polygons:
         polygon_img = draw_polygon(polygon, mislabelled_pixel_map.shape[-2:])
         polygon.lm_percentage = calculate_lm_polygon(mislabelled_pixel_map, polygon_img)
 

--- a/dataquality/utils/semantic_segmentation/lm.py
+++ b/dataquality/utils/semantic_segmentation/lm.py
@@ -340,17 +340,17 @@ def _semseg_calculate_confidence_joint(
 
 
 def upload_mislabeled_pixels(
-    self_confidence: torch.Tensor, image_ids: List[int], prefix: str
+    mislabeled_pixels: torch.Tensor, image_ids: List[int], prefix: str
 ) -> None:
     """Uploads all self confidence values to minio
 
     Args:
-        self_confidence (torch.Tensor): bs, h, w of value at gold
+        mislabeled_pixels (torch.Tensor): bs, h, w of value at gold
         image_ids (List[int]): integer image ids
         prefix (str): prefix to upload to
     """
     for i, image_id in enumerate(image_ids):
-        img = (self_confidence[i].numpy() * 255).astype(np.uint8)
+        img = (mislabeled_pixels[i].numpy() * 255).astype(np.uint8)
         img = Image.fromarray(img, mode="L")
         img = img.resize((64, 64))
         upload_im(img, prefix, image_id)

--- a/dataquality/utils/semantic_segmentation/metrics.py
+++ b/dataquality/utils/semantic_segmentation/metrics.py
@@ -126,7 +126,7 @@ def calculate_image_dep(dep_heatmap: torch.Tensor) -> List[float]:
 
 def calculate_area_per_class(
     pred_masks: torch.Tensor, gold_masks: torch.Tensor, nc: int
-) -> List[np.ndarray]:
+) -> np.ndarray:
     """Calculates the union of the area per class for gold and predicted mask
 
     Args:

--- a/dataquality/utils/semantic_segmentation/metrics.py
+++ b/dataquality/utils/semantic_segmentation/metrics.py
@@ -124,9 +124,30 @@ def calculate_image_dep(dep_heatmap: torch.Tensor) -> List[float]:
     return dep_heatmap.mean(dim=(1, 2)).tolist()
 
 
+def calculate_area_per_class(
+    pred_masks: torch.Tensor, gold_masks: torch.Tensor, nc: int
+) -> List[np.ndarray]:
+    """Calculates the union of the area per class for gold and predicted mask
+
+    Args:
+        pred_mask: argmax of the prediction probabilities
+        gold_masks: ground truth mask
+
+    Returns:
+        List of area per class for each image in the batch
+    """
+    pred_per_class_area = (
+        torch.bincount(pred_masks.reshape(-1), minlength=nc).float().numpy()
+    )
+    gold_per_class_area = (
+        torch.bincount(gold_masks.reshape(-1), minlength=nc).float().numpy()
+    )
+    return pred_per_class_area + gold_per_class_area
+
+
 def calculate_mean_iou(
-    pred_masks: torch.Tensor, gold_masks: torch.Tensor, nc: int = 21
-) -> Tuple[List[float], List[np.ndarray]]:
+    pred_masks: torch.Tensor, gold_masks: torch.Tensor, nc: int
+) -> Tuple[List[float], List[np.ndarray], List[np.ndarray]]:
     """Calculates the Mean Intersection Over Union (mIoU) for each image in the batch
 
     :param pred_masks: argmax of the prediction probabilities
@@ -142,6 +163,7 @@ def calculate_mean_iou(
     metric = evaluate.load("mean_iou")
     mean_ious = []
     per_class_ious = []
+    per_class_area = []
 
     # for iou need shape (bs, 1, height, width) to get per mask iou
     for i in range(len(pred_masks)):
@@ -153,4 +175,7 @@ def calculate_mean_iou(
         )
         mean_ious.append(iou["mean_iou"].item())
         per_class_ious.append(iou["per_category_iou"])
-    return mean_ious, per_class_ious
+        per_class_area.append(
+            calculate_area_per_class(pred_masks[i], gold_masks[i], nc)
+        )
+    return mean_ious, per_class_ious, per_class_area

--- a/dataquality/utils/semantic_segmentation/metrics.py
+++ b/dataquality/utils/semantic_segmentation/metrics.py
@@ -8,6 +8,8 @@ from PIL import Image
 
 from dataquality.clients.objectstore import ObjectStore
 from dataquality.core._config import GALILEO_DEFAULT_RESULT_BUCKET_NAME
+from dataquality.schemas.semantic_segmentation import Polygon
+from dataquality.utils.semantic_segmentation.polygons import draw_polygon
 
 object_store = ObjectStore()
 
@@ -179,3 +181,48 @@ def calculate_mean_iou(
             calculate_area_per_class(pred_masks[i], gold_masks[i], nc)
         )
     return mean_ious, per_class_ious, per_class_area
+
+
+def calculate_area_per_polygon_batch(
+    polygon_batch: List[List[Polygon]],
+    size: Tuple[int, int],
+) -> None:
+    """Calculates the area for every polygon in a btach
+
+    Args:
+        polygon_batch (List[List[Polygon]]): list of each images polygons
+        size (Tuple[int, int]): shape to draw the polygons onto
+    """
+    for idx in range(len(polygon_batch)):
+        calculate_area_per_polygon(polygon_batch[idx], size)
+
+
+def calculate_area_per_polygon(
+    polygons: List[Polygon],
+    size: Tuple[int, int],
+) -> None:
+    """Calculates the area for every polygon in an image
+
+    Args:
+        polygons (List[Polygon]): list of each images polygons
+        size (Tuple[int, int]): shape to draw the polygons onto
+    """
+    for polygon in polygons:
+        polygon.area = calculate_area(polygon, size)
+
+
+def calculate_area(
+    polygon: Polygon,
+    size: Tuple[int, int],
+) -> int:
+    """Calculates the area for a polygon
+
+    Args:
+        polygon (Polygon): polygon to calculate area for
+        size (Tuple[int, int]): shape to draw the polygons onto
+
+    Returns:
+        float: area of the polygon
+    """
+    polygon_img = draw_polygon(polygon, size)
+    return polygon_img.sum()


### PR DESCRIPTION
- Gave each pred polygon a dep score
- Created  a ghost error error type
- included the area in iou so we can do a weighted average
- Added following fields to polygon schema for recalculation based on thresholds: misclassified %, missing % and lm %
- Calculated all the above for gt polygon and did lm% and accuracy for pred polygons


Elliott request - Separate PRs:
- (1) pred polygon with dep
- (2) ghost error type
- (3) include area of union in image DF for weighted IoU
- (4) miscls, missing, lm%, at polygon level