### PR TITLE
Compute iou locally

### DIFF
--- a/dataquality/loggers/model_logger/semantic_segmentation.py
+++ b/dataquality/loggers/model_logger/semantic_segmentation.py
@@ -23,7 +23,7 @@ from dataquality.utils.semantic_segmentation.errors import (
 from dataquality.utils.semantic_segmentation.metrics import (
     add_area_to_polygons_batch,
     calculate_and_upload_dep,
-    calculate_mean_iou,
+    calculate_batch_iou,
 )
 from dataquality.utils.semantic_segmentation.polygons import (
     find_polygons_batch,
@@ -204,10 +204,10 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
 
         # Calculate metrics - mean IoU and boundary IoU
         n_classes = len(self.logger_config.labels)
-        mean_iou_data = calculate_mean_iou(
+        mean_iou_data = calculate_batch_iou(
             self.pred_masks, self.gold_masks, IoUType.mean, n_classes
         )
-        boundary_iou_data = calculate_mean_iou(
+        boundary_iou_data = calculate_batch_iou(
             self.pred_boundary_masks,
             self.gold_boundary_masks,
             IoUType.boundary,

--- a/dataquality/utils/semantic_segmentation/metrics.py
+++ b/dataquality/utils/semantic_segmentation/metrics.py
@@ -170,15 +170,15 @@ def calculate_batch_iou(
     :return: list of IoU data for each image in the batch
        shape = (bs,)
     """
-    pred_masks = pred_masks.numpy()
-    gold_masks = gold_masks.numpy()
+    pred_masks_np = pred_masks.numpy()
+    gold_masks_np = gold_masks.numpy()
     iou_data = []
 
     # for iou need shape (bs, 1, height, width) to get per mask iou
-    for i in range(len(pred_masks)):
+    for i in range(len(pred_masks_np)):
         iou, area_per_class = compute_iou(
-            pred_masks[i : i + 1],  # tensor (1, height, width)
-            gold_masks[i : i + 1],  # tensor (1, height, width)
+            pred_masks_np[i : i + 1],  # tensor (1, height, width)
+            gold_masks_np[i : i + 1],  # tensor (1, height, width)
             num_labels=nc,
         )
 

--- a/dataquality/utils/semantic_segmentation/metrics.py
+++ b/dataquality/utils/semantic_segmentation/metrics.py
@@ -31,6 +31,7 @@ def calculate_and_upload_dep(
     upload_dep_heatmaps(dep_heatmaps, image_ids, obj_prefix)
     return calculate_image_dep(dep_heatmaps), dep_heatmaps
 
+
 def colorize_dep_heatmap(image: Image.Image, dep_mean: int) -> Image.Image:
     """Recolors a grayscale image to a color image based on our dep mapping"""
     color_1 = ImageColor.getrgb("#9bc33f")  # Red
@@ -155,7 +156,7 @@ def calculate_image_dep(dep_heatmap: torch.Tensor) -> List[float]:
 
 
 def calculate_batch_iou(
-    pred_masks: np.ndarray, gold_masks: np.ndarray, iou_type: str, nc: int
+    pred_masks: torch.Tensor, gold_masks: torch.Tensor, iou_type: str, nc: int
 ) -> List[IouData]:
     """Calculates the Mean Intersection Over Union (mIoU) for each image in the batch
     If boundary masks are passed into this function, we return the
@@ -169,6 +170,8 @@ def calculate_batch_iou(
     :return: list of IoU data for each image in the batch
        shape = (bs,)
     """
+    pred_masks = pred_masks.numpy()
+    gold_masks = gold_masks.numpy()
     iou_data = []
 
     # for iou need shape (bs, 1, height, width) to get per mask iou

--- a/dataquality/utils/semantic_segmentation/metrics.py
+++ b/dataquality/utils/semantic_segmentation/metrics.py
@@ -1,14 +1,13 @@
 from tempfile import NamedTemporaryFile
 from typing import List, Tuple
 
-import evaluate
 import numpy as np
 import torch
 from PIL import Image
 
 from dataquality.clients.objectstore import ObjectStore
 from dataquality.core._config import GALILEO_DEFAULT_RESULT_BUCKET_NAME
-from dataquality.schemas.semantic_segmentation import IouData, IoUType, Polygon
+from dataquality.schemas.semantic_segmentation import IouData, Polygon
 from dataquality.utils.semantic_segmentation.polygons import draw_polygon
 
 object_store = ObjectStore()
@@ -138,7 +137,7 @@ def calculate_batch_iou(
        shape = (bs, height, width)
     :param iou_type: mean or boundary
     :param nc: number of classes
-    :return: list of IoU values for each image in the batch
+    :return: list of IoU data for each image in the batch
        shape = (bs,)
     """
     iou_data = []
@@ -168,7 +167,7 @@ def compute_iou(
     num_labels: int,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Computes the intersection over union for a single image
-    
+
     Computes the iou for a single image as well as returning the total union area
     per class
 


### PR DESCRIPTION
Compute iou locally instead of hitting hf hub - reduces dependency on hf hub and speeds up by about 4 seconds for 20 examples (55 down to 51) think this can be optimized further