### PR TITLE
Bug/save pca model gpumap

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -30,7 +30,7 @@ If you want to train without a model, you can use the auto framework:
         dataquality.get_insights()
 """
 
-__version__ = "v0.8.48"
+__version__ = "v0.8.49"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/utils/cuda.py
+++ b/dataquality/utils/cuda.py
@@ -1,4 +1,10 @@
+from typing import Tuple
+
 import numpy as np
+
+from dataquality.clients.objectstore import ObjectStore
+
+object_store = ObjectStore()
 
 PCA_CHUNK_SIZE = 100_000
 PCA_N_COMPONENTS = 100
@@ -13,16 +19,20 @@ def cuml_available() -> bool:
         return False
 
 
-def get_pca_embeddings(embs: np.ndarray) -> np.ndarray:
+def get_pca_embeddings(embs: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Uses Cuda and GPUs to create the PCA embeddings before uploading
 
     Should only be called if cuda ML available (`cuda_available()`)
+
+    Returns the PCA embeddings, the components_ of the pca model, and the mean_ of
+    the pca model
     """
     import cuml
 
     n_components = min(PCA_N_COMPONENTS, *embs.shape)
     pca = cuml.IncrementalPCA(n_components=n_components, batch_size=PCA_CHUNK_SIZE)
-    return pca.fit_transform(embs)
+    emb_pca = pca.fit_transform(embs)
+    return emb_pca, pca.components_, pca.mean_
 
 
 def get_umap_embeddings(embs: np.ndarray) -> np.ndarray:

--- a/dataquality/utils/emb.py
+++ b/dataquality/utils/emb.py
@@ -7,7 +7,6 @@ from huggingface_hub.utils import HfHubHTTPError
 from pydantic import UUID4
 from vaex.dataframe import DataFrame
 
-from dataquality import config
 from dataquality.clients.objectstore import ObjectStore
 from dataquality.utils.file import (
     get_largest_epoch_for_splits,
@@ -15,8 +14,6 @@ from dataquality.utils.file import (
 )
 from dataquality.utils.hdf5_store import HDF5_STORE
 from dataquality.utils.vaex import (
-    COMPONENTS,
-    MEAN,
     add_umap_pca_to_df,
     create_data_embs_df,
     get_output_df,
@@ -24,11 +21,6 @@ from dataquality.utils.vaex import (
 
 object_store = ObjectStore()
 DATA_EMB_PATH = "data_emb/data_emb.hdf5"
-
-PCA_COMPONENTS_NAME = "components.hdf5"
-PCA_COMPONENTS_OBJECT_PATH = f"pca/{PCA_COMPONENTS_NAME}"
-PCA_MEAN_NAME = "mean.hdf5"
-PCA_MEAN_OBJECT_PATH = f"pca/{PCA_MEAN_NAME}"
 
 
 def get_concat_emb_df(run_dir: str, split_epoch: Dict[str, int]) -> DataFrame:
@@ -66,26 +58,6 @@ def save_processed_emb_dfs(
         df.export(tmp_loc)
         os.remove(split_loc)
         os.rename(tmp_loc, split_loc)
-
-
-def _upload_pca_data(df: DataFrame) -> None:
-    project_id, run_id = config.current_project_id, config.current_run_id
-    # Save the components as an hdf5 file
-    components_file = f"/tmp/{PCA_COMPONENTS_NAME}"
-    components_object_path = f"{project_id}/{run_id}/{PCA_COMPONENTS_OBJECT_PATH}"
-    df[[COMPONENTS]].export(components_file)
-    bucket = config.results_bucket_name
-    object_store.create_object(
-        components_object_path, components_file, progress=False, bucket_name=bucket
-    )
-
-    # Save the mean as an hdf5 file
-    mean_file_path = f"/tmp/{PCA_MEAN_NAME}"
-    mean_object_path = f"{project_id}/{run_id}/{PCA_MEAN_OBJECT_PATH}"
-    df[[MEAN]].export(mean_file_path)
-    object_store.create_object(
-        mean_object_path, mean_file_path, progress=False, bucket_name=bucket
-    )
 
 
 def apply_umap_to_embs(run_dir: str, last_epoch: Optional[int]) -> None:


### PR DESCRIPTION
we need to save the pca data so that we can properly run inference. Inference needs the PCA data from training in order to get its embeddings in the same latent space, both for visualization and drift detection

## Tests
Installed from this branch, and did a run
![image](https://github.com/rungalileo/dataquality/assets/22605641/736ef5d1-1d82-4e98-acca-d727e6ec76f0)
[run](https://console.dev.rungalileo.io/insights?projectId=bde686ef-a80d-4881-9bb3-619a4f59bb69&runId=ba132870-6635-47ca-94e1-fb9b83cf88cc)

And see the pca model in minio
![image](https://github.com/rungalileo/dataquality/assets/22605641/dafbf96b-b518-46d9-8cde-057e26e90af3)

[data](https://data.dev.rungalileo.io/minio/galileo-project-runs-results/bde686ef-a80d-4881-9bb3-619a4f59bb69/ba132870-6635-47ca-94e1-fb9b83cf88cc/)

Then i did an inference run 
![image](https://github.com/rungalileo/dataquality/assets/22605641/270d5ea6-df0d-4b02-a47c-b7b32ccc72b7)

and the embeddings look correctly aligned
![image](https://github.com/rungalileo/dataquality/assets/22605641/c90e4fdd-37a3-4fc6-abbb-ea435af212ab)
