### PR TITLE
Move validation from IC to the base_model_logger / text_classification

### DIFF
--- a/dataquality/integrations/torch.py
+++ b/dataquality/integrations/torch.py
@@ -195,7 +195,7 @@ def watch(
     logits_fn: Optional[Callable] = None,
     last_hidden_state_layer: Union[Module, str, None] = None,
     unpatch_on_start: bool = False,
-    dataloader_random_sampling: bool = False,
+    dataloader_random_sampling: bool = True,
 ) -> None:
     """
     wraps a PyTorch model and optionally dataloaders to log the

--- a/dataquality/loggers/data_logger/image_classification.py
+++ b/dataquality/loggers/data_logger/image_classification.py
@@ -273,7 +273,7 @@ class ImageClassificationDataLogger(TextClassificationDataLogger):
         allow_missing_in_df_ids = cls.logger_config.dataloader_random_sampling
         filter_ids: Set[int] = set()
         if allow_missing_in_df_ids:
-            observed_ids = image_classification_logger_config.observed_ids
+            observed_ids = cls.logger_config.observed_ids
             keys = [k for k in observed_ids.keys() if split in k]
             if len(keys):
                 filter_ids = set(observed_ids[keys[0]])

--- a/dataquality/loggers/logger_config/base_logger_config.py
+++ b/dataquality/loggers/logger_config/base_logger_config.py
@@ -36,7 +36,11 @@ class BaseLoggerConfig(BaseModel):
     finish: Callable = lambda: None  # Overwritten in Semantic Segmentation
     # True when calling `init` with a run that already exists
     existing_run: bool = False
-    dataloader_random_sampling = False
+    dataloader_random_sampling = True
+    # Keep track of the ids that have been observed in the current epoch
+    # the key is the split and epoch like observed_ids["train_0"] = {0, 1, 2, 3}
+    observed_ids: Dict[str, set] = dict()
+    all_ids: Dict[str, set] = dict()
 
     class Config:
         validate_assignment = True

--- a/dataquality/loggers/logger_config/image_classification.py
+++ b/dataquality/loggers/logger_config/image_classification.py
@@ -1,15 +1,10 @@
-from typing import Dict
-
 from dataquality.loggers.logger_config.text_classification import (
     TextClassificationLoggerConfig,
 )
 
 
 class ImageClassificationLoggerConfig(TextClassificationLoggerConfig):
-    # Keep track of the ids that have been observed in the current epoch
-    # the key is the split and epoch like observed_ids["train_0"] = {0, 1, 2, 3}
-    observed_ids: Dict[str, set] = dict()
-    all_ids: Dict[str, set] = dict()
+    pass
 
 
 image_classification_logger_config = ImageClassificationLoggerConfig()

--- a/dataquality/loggers/model_logger/image_classification.py
+++ b/dataquality/loggers/model_logger/image_classification.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 
@@ -8,7 +8,6 @@ from dataquality.loggers.logger_config.image_classification import (
 from dataquality.loggers.model_logger.text_classification import (
     TextClassificationModelLogger,
 )
-from dataquality.utils.dq_logger import get_dq_logger
 
 
 class ImageClassificationModelLogger(TextClassificationModelLogger):
@@ -35,41 +34,6 @@ class ImageClassificationModelLogger(TextClassificationModelLogger):
             inference_name=inference_name,
         )
 
-    def _filter_duplicate_ids(self) -> None:
-        """To avoid duplicate ids, when augmentation is used.
-        Filter out duplicate ids in the batch. This is done by keeping track of
-        the ids that have been observed in the current epoch in the config"""
-
-        key = f"{self.split}_{self.epoch}"
-        if key not in self.logger_config.observed_ids:
-            self.logger_config.observed_ids[key] = set()
-        observed_ids = self.logger_config.observed_ids[key]
-        unique_ids: Set = set()
-        unique_ids.update(self.ids)
-        _unique_ids = unique_ids.difference(observed_ids)
-        observed_ids.update(_unique_ids)
-        id_to_index = dict()
-        for index, id in enumerate(self.ids):
-            id_to_index[id] = index
-
-        # If there are duplicate ids, filter out the duplicates
-        if len(self.ids) > len(_unique_ids):
-            # cur_epoch = get_data_logger().logger_config.cur_epoch
-
-            get_dq_logger().warning(
-                f"Duplicate ids found in epoch. {self.epoch}"
-                f"Batch size: {len(self.ids)}, "
-                f"Unique ids: {len(_unique_ids)}"
-                f"Split: {self.split}"
-            )
-            unique_indices = [id_to_index[id] for id in _unique_ids]
-            if len(self.embs) > 0:
-                self.embs = np.array(self.embs)[unique_indices]
-            if len(self.probs) > 0:
-                self.probs = np.array(self.probs)[unique_indices]
-            if len(self.ids) > 0:
-                self.ids = np.array(self.ids)[unique_indices]
-
     def write_model_output(self, model_output: Dict) -> None:
         """Only write model output if there is data to write.
 
@@ -82,6 +46,4 @@ class ImageClassificationModelLogger(TextClassificationModelLogger):
 
     def _get_data_dict(self) -> Dict[str, Any]:
         # Handle the binary case by converting it to 2-class classification
-        self._filter_duplicate_ids()
-
         return super()._get_data_dict()

--- a/dataquality/utils/vaex.py
+++ b/dataquality/utils/vaex.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import Dict, List, Union
 
 import numpy as np
@@ -38,7 +39,7 @@ PCA_MEAN_OBJECT_PATH = f"pca/{PCA_MEAN_NAME}"
 
 
 def _join_in_out_frames(
-    in_df: DataFrame, out_df: DataFrame, allow_missing_in_df_ids: bool = False
+    in_df: DataFrame, out_df: DataFrame, allow_missing_in_df_ids: bool = True
 ) -> DataFrame:
     """Helper function to join our input and output frames"""
     in_frame = in_df.copy()
@@ -61,6 +62,8 @@ def _join_in_out_frames(
     elif allow_missing_in_df_ids:
         # If we're downsampling, we make sure the out and in have an id intersection
         # and then we drop the out rows that don't have a corresponding in
+        if len(in_out) != len(out_frame):
+            warnings.warn("There are IDs that have not been logged by the model.")
         in_ids = set(in_frame["id"].unique())
         out_ids = set(out_frame["id"].unique())
         id_intersection = np.array(list(in_ids.intersection(out_ids)))

--- a/tests/loggers/test_text_classification.py
+++ b/tests/loggers/test_text_classification.py
@@ -70,11 +70,7 @@ def test_duplicate_output_rows(set_test_config, cleanup_after_use) -> None:
     ids = list(range(5))
     dq.log_model_outputs(embs=embs, logits=logits, ids=ids, split="training", epoch=0)
     dq.log_model_outputs(embs=embs, logits=logits, ids=ids, split="training", epoch=0)
-
-    with pytest.raises(GalileoException) as e:
-        dq.get_data_logger().upload()
-
-    assert str(e.value).startswith("It seems your logged output data has duplicate ids")
+    dq.get_data_logger().upload()
 
 
 def test_log_data_sample(

--- a/tests/test_dataquality.py
+++ b/tests/test_dataquality.py
@@ -219,12 +219,8 @@ def test_logging_duplicate_ids(
         # Equivalent to the users `finish` call, but we don't want to clean up files yet
         ThreadPoolManager.wait_for_threads()
         c = dataquality.get_data_logger("text_classification")
-        with pytest.raises(GalileoException) as e:
-            c.upload()
+        c.upload()
 
-        assert str(e.value).startswith(
-            "It seems your logged output data has duplicate ids"
-        )
     finally:
         # Mock finish() call without calling the API
         ThreadPoolManager.wait_for_threads()


### PR DESCRIPTION
- move the logic for random sampling to both IC and TC in torch and HF
- Allow duplicate IDs during training steps