### PR TITLE
Use the config buckets for semseg, fixes enterprise flow

### DIFF
--- a/dataquality/integrations/torch_semantic_segmentation.py
+++ b/dataquality/integrations/torch_semantic_segmentation.py
@@ -14,7 +14,6 @@ from dataquality import config
 from dataquality.analytics import Analytics
 from dataquality.clients.api import ApiClient
 from dataquality.clients.objectstore import ObjectStore
-from dataquality.core._config import GALILEO_DEFAULT_RESULT_BUCKET_NAME
 from dataquality.exceptions import GalileoException
 from dataquality.integrations.torch import TorchLogger, unwatch
 from dataquality.loggers.model_logger.semantic_segmentation import (
@@ -438,7 +437,7 @@ class SemanticTorchLogger(TorchLogger):
             file_path=temp_file.name,
             content_type="application/json",
             progress=False,
-            bucket_name=GALILEO_DEFAULT_RESULT_BUCKET_NAME,
+            bucket_name=config.results_bucket_name,
         )
 
     def upload_dep_split(self, split: str) -> None:
@@ -468,7 +467,7 @@ class SemanticTorchLogger(TorchLogger):
             temp_dir=local_dep_path,
             export_format="arrow",
             show_progress=False,
-            bucket=GALILEO_DEFAULT_RESULT_BUCKET_NAME,
+            bucket=config.results_bucket_name,
             use_data_md5_hash=False,
         )
 

--- a/dataquality/loggers/data_logger/image_classification.py
+++ b/dataquality/loggers/data_logger/image_classification.py
@@ -145,6 +145,7 @@ class ImageClassificationDataLogger(TextClassificationDataLogger):
                 export_cols=["data", "object_path"],
                 project_id=project_id,
                 temp_dir=temp_dir,
+                bucket=config.images_bucket_name,
                 parallel=parallel,
                 export_format=export_format,
                 use_data_md5_hash=True,

--- a/dataquality/loggers/data_logger/image_classification.py
+++ b/dataquality/loggers/data_logger/image_classification.py
@@ -80,7 +80,7 @@ class ImageClassificationDataLogger(TextClassificationDataLogger):
         For docstring see top level method located in core/log.py
         """
         if type(dataset).__name__ == "ImageFolder":
-            dataset = self._prepare_df_from_ImageFolder(dataset, imgs_remote_location, split)
+            dataset = self._prepare_df_from_ImageFolder(dataset, imgs_remote_location)
             imgs_location_colname = "text"
 
         if imgs_colname is None and imgs_location_colname is None:

--- a/dataquality/loggers/data_logger/image_classification.py
+++ b/dataquality/loggers/data_logger/image_classification.py
@@ -80,7 +80,7 @@ class ImageClassificationDataLogger(TextClassificationDataLogger):
         For docstring see top level method located in core/log.py
         """
         if type(dataset).__name__ == "ImageFolder":
-            dataset = self._prepare_df_from_ImageFolder(dataset, imgs_remote_location)
+            dataset = self._prepare_df_from_ImageFolder(dataset, imgs_remote_location, split)
             imgs_location_colname = "text"
 
         if imgs_colname is None and imgs_location_colname is None:

--- a/dataquality/utils/semantic_segmentation/metrics.py
+++ b/dataquality/utils/semantic_segmentation/metrics.py
@@ -6,8 +6,8 @@ import numpy as np
 import torch
 from PIL import Image, ImageColor
 
+from dataquality import config
 from dataquality.clients.objectstore import ObjectStore
-from dataquality.core._config import GALILEO_DEFAULT_RESULT_BUCKET_NAME
 from dataquality.schemas.semantic_segmentation import IouData, Polygon
 from dataquality.utils.semantic_segmentation.polygons import draw_polygon
 
@@ -144,7 +144,7 @@ def upload_dep_heatmaps(
                 file_path=f.name,
                 content_type="image/png",
                 progress=False,
-                bucket_name=GALILEO_DEFAULT_RESULT_BUCKET_NAME,
+                bucket_name=config.results_bucket_name,
             )
 
 

--- a/dataquality/utils/upload.py
+++ b/dataquality/utils/upload.py
@@ -11,7 +11,6 @@ import vaex
 from pydantic import UUID4
 from tqdm import tqdm
 
-from dataquality import config
 from dataquality.clients.api import ApiClient
 
 api_client = ApiClient()
@@ -117,9 +116,9 @@ def chunk_load_then_upload_df(
     file_list: List[str],
     export_cols: List[str],
     temp_dir: str,
+    bucket: str,
     project_id: Optional[UUID4] = None,
     object_path: Optional[str] = None,
-    bucket: str = config.images_bucket_name,
     parallel: bool = False,
     step: int = 50,
     num_workers: int = 1,

--- a/dataquality/utils/upload.py
+++ b/dataquality/utils/upload.py
@@ -11,8 +11,8 @@ import vaex
 from pydantic import UUID4
 from tqdm import tqdm
 
+from dataquality import config
 from dataquality.clients.api import ApiClient
-from dataquality.core._config import GALILEO_DEFAULT_IMG_BUCKET_NAME
 
 api_client = ApiClient()
 
@@ -119,7 +119,7 @@ def chunk_load_then_upload_df(
     temp_dir: str,
     project_id: Optional[UUID4] = None,
     object_path: Optional[str] = None,
-    bucket: str = GALILEO_DEFAULT_IMG_BUCKET_NAME,
+    bucket: str = config.images_bucket_name,
     parallel: bool = False,
     step: int = 50,
     num_workers: int = 1,


### PR DESCRIPTION
Fix for semseg in enterprise buckets

Notebook demonstrating the issue https://colab.research.google.com/drive/1Xc8Xzlc24nDwax1-7XXDD1RluEQqUIw6#scrollTo=CAqZVAbiXryu

In semseg we need to use the default buckets as specified by the backend (which are different if your cloud vendor is not minio), not the default minio bucket names


https://app.shortcut.com/galileo/story/5880/api-ml-test-runs-with-s3-gcs-private-buckets?ct_workflow=all&cf_workflow=500000005