### PR TITLE
downcast before saving batch

### DIFF
--- a/dataquality/loggers/model_logger/base_model_logger.py
+++ b/dataquality/loggers/model_logger/base_model_logger.py
@@ -73,7 +73,18 @@ class BaseGalileoModelLogger(BaseGalileoLogger):
             )
             return
         data = self._get_data_dict()
+        data = self._downcast_data_dict(data)
         self.write_model_output(data)
+
+    def _downcast_data_dict(self, data: Dict) -> Dict:
+        """Downcasts any float/int 64 types to 32 before saving batch"""
+        for key, val in data.items():
+            if isinstance(val, np.ndarray):
+                if val.dtype == np.int64:
+                    data[key] = val.astype(np.int32)
+                elif val.dtype == np.float64:
+                    data[key] = val.astype(np.float32)
+        return data
 
     def _add_threaded_log(self) -> None:
         try:


### PR DESCRIPTION
we've done this in a few places before uploading to Galileo, but we still write the batches to disk. This can really add up (f64 embeddings are huge).

Safely always downcast before writing to disk