### PR TITLE
Pin pydantic below 2

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 
 import sys
 from typing import Any, List, Optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = {text = 'See LICENSE'}
 requires-python = ">=3.7"
 dependencies = [
-    "pydantic>=1.8.2",
+    "pydantic>=1.8.2,<2.0.0",
     "requests>=2.25.1",
     "types-requests>=2.25.2",
     "pandas>=0.20.0",


### PR DESCRIPTION
DQ doesn't work with pydantic 2

pydantic docs https://docs.pydantic.dev/dev-v2/migration/

```
>>> import dataquality
/Users/elliottchartock/Code/.venv/lib/python3.9/site-packages/pydantic/_internal/_config.py:261: UserWarning: Valid config keys have changed in V2:
* 'underscore_attrs_are_private' has been removed
  warnings.warn(message, UserWarning)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/elliottchartock/Code/.venv/lib/python3.9/site-packages/dataquality/__init__.py", line 39, in <module>
    import dataquality.core._config
  File "/Users/elliottchartock/Code/.venv/lib/python3.9/site-packages/dataquality/core/__init__.py", line 6, in <module>
    from dataquality.analytics import Analytics
  File "/Users/elliottchartock/Code/.venv/lib/python3.9/site-packages/dataquality/analytics.py", line 10, in <module>
    from dataquality.clients.api import ApiClient
  File "/Users/elliottchartock/Code/.venv/lib/python3.9/site-packages/dataquality/clients/api.py", line 14, in <module>
    from dataquality.schemas.dataframe import FileType
  File "/Users/elliottchartock/Code/.venv/lib/python3.9/site-packages/dataquality/schemas/dataframe.py", line 5, in <module>
    from vaex.dataframe import DataFrame
  File "/Users/elliottchartock/Code/.venv/lib/python3.9/site-packages/vaex/__init__.py", line 41, in <module>
    import vaex.logging
  File "/Users/elliottchartock/Code/.venv/lib/python3.9/site-packages/vaex/logging.py", line 7, in <module>
    import vaex.settings
  File "/Users/elliottchartock/Code/.venv/lib/python3.9/site-packages/vaex/settings.py", line 10, in <module>
    from pydantic import BaseModel, BaseSettings, Field
  File "/Users/elliottchartock/Code/.venv/lib/python3.9/site-packages/pydantic/__init__.py", line 206, in __getattr__
    return _getattr_migration(attr_name)
  File "/Users/elliottchartock/Code/.venv/lib/python3.9/site-packages/pydantic/_migration.py", line 279, in wrapper
    raise PydanticImportError(
pydantic.errors.PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package. See https://docs.pydantic.dev/2.0.2/migration/#basesettings-has-moved-to-pydantic-settings for more details.

For further information visit https://errors.pydantic.dev/2.0.2/u/import-error
```