### PR TITLE
chore: Add py37 warning

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -35,9 +35,11 @@ __version__ = "0.9.8"
 
 import sys
 from typing import Any, List, Optional
+from warnings import warn
 
 import dataquality.core._config
 import dataquality.integrations
+from dataquality.exceptions import GalileoWarning
 
 # We try/catch this in case the user installed dq inside of jupyter. You need to
 # restart the kernel after the install and we want to make that clear. This is because
@@ -142,6 +144,16 @@ try:
     resource.setrlimit(resource.RLIMIT_NOFILE, (65535, 65535))
 except (ImportError, ValueError):  # The users limit is higher than our max, which is OK
     pass
+
+# Warn if the user is using an old version of Python.
+if sys.version_info < (3, 8):
+    warn(
+        "You are using an old version of Python. Please upgrade to Python 3.8"
+        "or higher. dataquality will stop supporting Python 3.7 in the near "
+        "future.",
+        GalileoWarning,
+    )
+
 
 #  Logging is optional. If enabled, imports, method calls
 #  and exceptions can be logged by calling the logger.

--- a/dataquality/analytics.py
+++ b/dataquality/analytics.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import uuid
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from types import TracebackType
 from typing import Any, Dict, Optional, Tuple, Type
@@ -9,6 +10,7 @@ from pydantic import BaseModel
 
 from dataquality.clients.api import ApiClient
 from dataquality.core._config import Config
+from dataquality.exceptions import GalileoWarning
 from dataquality.utils.ampli import AmpliMetric
 from dataquality.utils.patcher import Borg
 from dataquality.utils.profiler import (
@@ -40,6 +42,15 @@ class Analytics(Borg):
         :param config: The dq config
         """
         super().__init__()
+
+        # Warn if the user is using an old version of Python.
+        if sys.version_info < (3, 8):
+            warnings.warn(
+                "You are using an old version of Python. Please upgrade to Python 3.8"
+                "or higher. dataquality will stop supporting Python 3.7 in the near "
+                "future.",
+                GalileoWarning,
+            )
 
         try:
             self._telemetrics_disabled = self._is_telemetrics_disabled(config)

--- a/dataquality/analytics.py
+++ b/dataquality/analytics.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import uuid
-import warnings
 from concurrent.futures import ThreadPoolExecutor
 from types import TracebackType
 from typing import Any, Dict, Optional, Tuple, Type
@@ -10,7 +9,6 @@ from pydantic import BaseModel
 
 from dataquality.clients.api import ApiClient
 from dataquality.core._config import Config
-from dataquality.exceptions import GalileoWarning
 from dataquality.utils.ampli import AmpliMetric
 from dataquality.utils.patcher import Borg
 from dataquality.utils.profiler import (
@@ -42,15 +40,6 @@ class Analytics(Borg):
         :param config: The dq config
         """
         super().__init__()
-
-        # Warn if the user is using an old version of Python.
-        if sys.version_info < (3, 8):
-            warnings.warn(
-                "You are using an old version of Python. Please upgrade to Python 3.8"
-                "or higher. dataquality will stop supporting Python 3.7 in the near "
-                "future.",
-                GalileoWarning,
-            )
 
         try:
             self._telemetrics_disabled = self._is_telemetrics_disabled(config)

--- a/dataquality/integrations/ultralytics.py
+++ b/dataquality/integrations/ultralytics.py
@@ -3,9 +3,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin
 
 import torch
-import ultralytics
 from torchvision.ops.boxes import box_convert
-from ultralytics import YOLO
+from ultralytics import YOLO, checks
 from ultralytics.yolo.engine.predictor import BasePredictor
 from ultralytics.yolo.engine.trainer import BaseTrainer
 from ultralytics.yolo.engine.validator import BaseValidator
@@ -24,7 +23,7 @@ from dataquality.schemas.task_type import TaskType
 from dataquality.utils.dqyolo import CONF_DEFAULT, IOU_DEFAULT
 from dataquality.utils.ultralytics import non_max_suppression, process_batch_data
 
-ultralytics.checks()
+checks()
 
 Coordinates = Union[Tuple, List]
 


### PR DESCRIPTION
During the import of `dataquality`, start warning users that we're going to be dropping Python 3.7 support soon.