### PR TITLE
chore: Bump CodeCov action to v3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,6 @@ jobs:
         run: inv test
 
       - name: upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos


### PR DESCRIPTION
Codecov v1 is [deprecated](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1).