### PR TITLE
fix: Use tmpdir for Ultralytics' YOLO config

### DIFF
--- a/tests/integrations/ultralytics/conftest.py
+++ b/tests/integrations/ultralytics/conftest.py
@@ -1,0 +1,15 @@
+from typing import Generator
+
+from pytest import MonkeyPatch, fixture
+
+
+@fixture(autouse=True, scope="function")
+def set_ultralytics_config_dir(
+    tmpdir: str, monkeypatch: MonkeyPatch
+) -> Generator[None, None, None]:
+    # Ensure we use different config dirs for each time `ultralytics` is imported.
+    # https://github.com/ultralytics/ultralytics/blob/main/ultralytics/utils/__init__.py
+    # #L550-L582
+    monkeypatch.setenv("YOLO_CONFIG_DIR", tmpdir)
+    yield
+    monkeypatch.delenv("YOLO_CONFIG_DIR")


### PR DESCRIPTION
Turns out the test that was failing in #720 was just being flaky, because of an upstream change in settings management for `ultralytics` (https://github.com/ultralytics/ultralytics/pull/3790).

This improves how we handle it.

Tests:
- [x] Local.
- [ ] CI.