### PR TITLE
Only throw warning if not associated with semseg

### DIFF
--- a/dataquality/integrations/torch.py
+++ b/dataquality/integrations/torch.py
@@ -96,17 +96,18 @@ class TorchLogger(TorchBaseInstance):
                 model, self._dq_classifier_hook_with_step_end, classifier_layer
             )
         except Exception as e:
-            warn(
-                "Could not attach function to model layer. Error:"
-                f" {e}. Please check that the classifier layer name:"
-                f" {classifier_layer} exists in the model. Common layers"
-                " to extract logits and the last hidden state are 'classifier'"
-                "and 'fc'. To fix this, pass the correct layer name to the "
-                "'classifier_layer' parameter in the 'watch' function. "
-                "For example: 'watch(model, classifier_layer='fc')'."
-                "You can view the model layers by using the 'model.named_children'"
-                "function or by printing the model."
-            )
+            if dq.config.task_type != TaskType.semantic_segmentation:
+                warn(
+                    "Could not attach function to model layer. Error:"
+                    f" {e}. Please check that the classifier layer name:"
+                    f" {classifier_layer} exists in the model. Common layers"
+                    " to extract logits and the last hidden state are 'classifier'"
+                    "and 'fc'. To fix this, pass the correct layer name to the "
+                    "'classifier_layer' parameter in the 'watch' function. "
+                    "For example: 'watch(model, classifier_layer='fc')'."
+                    "You can view the model layers by using the 'model.named_children'"
+                    "function or by printing the model."
+                )
             self.hook_manager.attach_hooks_to_model(
                 model, self._dq_embedding_hook, last_hidden_state_layer
             )

--- a/dataquality/integrations/torch.py
+++ b/dataquality/integrations/torch.py
@@ -98,7 +98,7 @@ class TorchLogger(TorchBaseInstance):
         except Exception as e:
             if dq.config.task_type != TaskType.semantic_segmentation:
                 warn(
-                    "Could not attach function to model layer. Error:"
+                    "Warning: Could not attach function to model layer."
                     f" {e}. Please check that the classifier layer name:"
                     f" {classifier_layer} exists in the model. Common layers"
                     " to extract logits and the last hidden state are 'classifier'"


### PR DESCRIPTION
Warning for not finding the classification layer should not be thrown in the case of semseg so we ignore as we do not need to know layers, all we need to know are outputs and inputs