### PR TITLE
Pin ipywidgets to avoid iprogress bar import issue

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 
 import sys
 from typing import Any, List, Optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "tenacity>=8.1.0",
     "evaluate",
     "accelerate",
+    "ipywidgets>=8.1.0",
 ]
 [[project.authors]]
 name = "Galileo Technologies, Inc."


### PR DESCRIPTION
Use the latest version of [ipywidgets](https://pypi.org/project/ipywidgets/)

https://app.shortcut.com/galileo/story/6871/dq-pyproject-progress-bar-dependency#activity-6872