### PR TITLE
Remove python 37

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
       fail-fast: false
 
     steps:
@@ -30,12 +30,7 @@ jobs:
         run: pip install invoke
 
       - name: install dependencies
-        run: |
-          if [[ ${{ matrix.python-version }} == "3.7" ]]; then
-            inv install --no-editable --extras dev,test,doc,py37
-          else
-            inv install --no-editable
-          fi
+        run: inv install --no-editable
 
       - name: lint
         run: inv lint

--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -35,11 +35,9 @@ __version__ = "0.11.0"
 
 import sys
 from typing import Any, List, Optional
-from warnings import warn
 
 import dataquality.core._config
 import dataquality.integrations
-from dataquality.exceptions import GalileoWarning
 
 # We try/catch this in case the user installed dq inside of jupyter. You need to
 # restart the kernel after the install and we want to make that clear. This is because
@@ -146,14 +144,6 @@ try:
     resource.setrlimit(resource.RLIMIT_NOFILE, (65535, 65535))
 except (ImportError, ValueError):  # The users limit is higher than our max, which is OK
     pass
-
-# Warn if the user is using an old version of Python.
-if sys.version_info < (3, 8):
-    warn(
-        "You are using an old version of Python. Please upgrade to Python 3.8"
-        "or higher. dataquality does not support Python 3.7 ",
-        GalileoWarning,
-    )
 
 
 #  Logging is optional. If enabled, imports, method calls

--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "0.11.0"
+__version__ = "1.0.0"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "0.10.3"
+__version__ = "0.11.0"
 
 import sys
 from typing import Any, List, Optional
@@ -151,8 +151,7 @@ except (ImportError, ValueError):  # The users limit is higher than our max, whi
 if sys.version_info < (3, 8):
     warn(
         "You are using an old version of Python. Please upgrade to Python 3.8"
-        "or higher. dataquality will stop supporting Python 3.7 in the near "
-        "future.",
+        "or higher. dataquality does not support Python 3.7 ",
         GalileoWarning,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "dataquality"
 dynamic = ["version"]
 readme = "README.md"
 license = {text = 'See LICENSE'}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "pydantic>=1.8.2,<2.0.0",
     "requests>=2.25.1",
@@ -107,12 +107,6 @@ cuda = [
 ]
 minio = [
     "minio>=7.1.0,<7.2.0"
-]
-py37 = [
-    "cachetools>=5.2.0",
-    "types-cachetools>=5.3.0.0",
-    "importlib-metadata<5.0.0",
-    "timm<=0.6.13",
 ]
 setfit = [
     "setfit"

--- a/tests/test_dataquality.py
+++ b/tests/test_dataquality.py
@@ -619,11 +619,7 @@ def test_finish_last_epoch(
         min(last_logged_epoch, last_epoch + 1) if last_epoch else last_logged_epoch
     )
     for i, call in enumerate(mock_upload_frames.call_args_list):
-        # python 3.7 vs 3.8+ compatibility
-        try:  # python 3.8+
-            assert int(call.args[-1]) == i
-        except TypeError:  # python 3.7
-            assert int(call[0][-1]) == i
+        assert int(call.args[-1]) == i
     assert mock_upload_frames.call_count == max_uploaded
 
 


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/6981/dq-remove-support-for-python-3-7


Additional context: https://galileoteamworkspace.slack.com/archives/C02NSBN4ZK3/p1690213086742379


From https://www.python.org/downloads/release/python-3717/
```
Note: The release you are looking at is Python 3.7.17, the final security bugfix release for the legacy 3.7 series which has now reached end-of-life and is no longer supported. See the downloads page for currently supported versions of Python.
```

