### PR TITLE
Fix/Create out logdir before instantiating logger

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/utils/dq_logger.py
+++ b/dataquality/utils/dq_logger.py
@@ -50,7 +50,10 @@ def get_dq_logger() -> CustomSplitAdapter:
 
 
 def dq_log_file_path(run_id: Optional[UUID4] = None) -> str:
+    os.makedirs(DQ_LOG_FILE_HOME, exist_ok=True)
     rid = run_id or config.current_run_id
+    if not rid:
+        return f"{DQ_LOG_FILE_HOME}/{DQ_LOG_FILE}"
     return f"{DQ_LOG_FILE_HOME}/{rid}/{DQ_LOG_FILE}"
 
 


### PR DESCRIPTION
https://github.com/rungalileo/feedback/issues/2

Shortcut: https://app.shortcut.com/galileo/story/7053/dq-bug-filenotfounderror-errno-2-no-such-file-or-directory-root-galileo-out-none-out-log

This error was caused by an issue surfaced by the new major version mismatch, wherein we log a warning to stdout before the local config is assigned a run id. To fix, we create the dir `.galileo/out` before instantiating the stdout logger in case it doesn't exist yet. 