### PR TITLE
Feature/auto tokenizer

### DIFF
--- a/dataquality/dq_auto/tc_trainer.py
+++ b/dataquality/dq_auto/tc_trainer.py
@@ -1,6 +1,5 @@
-from dataclasses import dataclass
 from functools import partial
-from typing import Any, Dict, List, Tuple, Optional
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 from datasets import Dataset, DatasetDict

--- a/dataquality/dq_auto/tc_trainer.py
+++ b/dataquality/dq_auto/tc_trainer.py
@@ -1,5 +1,6 @@
+from dataclasses import dataclass
 from functools import partial
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Optional
 
 import numpy as np
 from datasets import Dataset, DatasetDict
@@ -38,8 +39,9 @@ except ImportError:
 def preprocess_function(
     input_data: Dataset, tokenizer: PreTrainedTokenizerBase, max_length: int
 ) -> BatchEncoding:
+    # Delay padding until batching - allowing for dynamic padding
     return tokenizer(
-        input_data["text"], padding="max_length", max_length=max_length, truncation=True
+        input_data["text"], padding=False, max_length=max_length, truncation=True
     )
 
 
@@ -103,7 +105,7 @@ def get_trainer(
         args=args,
         train_dataset=encoded_datasets[Split.train],  # type: ignore
         eval_dataset=encoded_datasets.get(Split.validation),  # type: ignore
-        tokenizer=tokenizer,
+        tokenizer=tokenizer,  # Ensures we use hf's default DataCollatorWithPadding
         compute_metrics=compute_metrics_partial,
         callbacks=callbacks,
     )

--- a/dataquality/utils/jsl.py
+++ b/dataquality/utils/jsl.py
@@ -25,7 +25,7 @@ MAX_TOKEN_LEN = 512
 PipelineLike = Union[Pipeline, LightPipeline, PipelineModel, PretrainedPipeline]
 
 
-def extract_begin_end(token_list: list[Row]) -> List[List[int]]:
+def extract_begin_end(token_list: List[Row]) -> List[List[int]]:
     """Extracts the begin and end of each token in a list of tokens
     :param token_list: A list of tokens
     :return: A list of lists of integers, where each sublist contains the begin and
@@ -35,7 +35,7 @@ def extract_begin_end(token_list: list[Row]) -> List[List[int]]:
     return [[row.begin, row.end + 1] for row in token_list]
 
 
-def extract_embeddings(embeddings_list: list[Row]) -> List[List[float]]:
+def extract_embeddings(embeddings_list: List[Row]) -> List[List[float]]:
     """Extracts the embeddings from a list of embeddings
     :param embeddings_list: A list of embeddings
     :return: A list of lists of floats, where each sublist contains the embeddings


### PR DESCRIPTION
***What existing issue does this pull request close?***

This is a very small PR to address this shortcut [ticket](https://app.shortcut.com/galileo/story/7664/dq-improve-tokenization-in-dq-auto)

In `dq.auto` we introduce a small change to the `tokenization` scheme to improve the padding efficiency. Rather than padding every sequence to the user specified `max_length`, we delay padding until the creation of batches. This allows us to dynamically pad to just the longest sequence in the batch.

This is a very easy change with `hf.Trainer`. By default if we *do not* specify a `DataCollator` but include our `tokenizer`, `hf.Trainer` uses the `DataCollatorWithPadding`. This Collator is a pretty simple wrapper around `tokenizer.pad(...)`, which does exactly what we want!

***Demonstration***

As a little reference, here is behind the scenes what `DataCollatorWithPadding` does:
```
    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, Any]:
        batch = self.tokenizer.pad(
            features,
            padding=self.padding,
            max_length=self.max_length,
            pad_to_multiple_of=self.pad_to_multiple_of,
            return_tensors=self.return_tensors,
        )
        if "label" in batch:
            batch["labels"] = batch["label"]
            del batch["label"]
        if "label_ids" in batch:
            batch["labels"] = batch["label_ids"]
            del batch["label_ids"]
        return batch
```
where `padding=True` be default meaning we pad to the longest sequence in the batch. Also it converts 'label' to 'labels', which is what the model expects!
