### PR TITLE
fix: generation without vaex

### DIFF
--- a/dataquality/schemas/seq2seq.py
+++ b/dataquality/schemas/seq2seq.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import List, Set, Tuple
 
@@ -125,6 +125,7 @@ class BatchGenerationData:
     top_logprobs: List[List[List[Tuple[str, float]]]]
         top_logprobs for each sample
     """
+
     generated_outputs: List[str]
     generated_token_label_positions: List[List[Set[int]]]
     generated_token_label_offsets: List[List[Tuple[int, int]]]
@@ -132,14 +133,14 @@ class BatchGenerationData:
     generated_top_logprobs: List[List[List[Tuple[str, float]]]]
 
     @classmethod
-    def empty_init(cls) -> 'BatchGenerationData':
+    def empty_init(cls) -> "BatchGenerationData":
         """Initialize a BatchGenerationData object with no sample data"""
         return cls(
             generated_outputs=[],
             generated_token_label_positions=[],
             generated_token_label_offsets=[],
             generated_token_logprobs=[],
-            generated_top_logprobs=[]
+            generated_top_logprobs=[],
         )
 
     def extend_from(self, batch_data: "BatchGenerationData") -> None:
@@ -149,7 +150,11 @@ class BatchGenerationData:
         memory and performance.
         """
         self.generated_outputs.extend(batch_data.generated_outputs)
-        self.generated_token_label_positions.extend(batch_data.generated_token_label_positions)
-        self.generated_token_label_offsets.extend(batch_data.generated_token_label_offsets)
+        self.generated_token_label_positions.extend(
+            batch_data.generated_token_label_positions
+        )
+        self.generated_token_label_offsets.extend(
+            batch_data.generated_token_label_offsets
+        )
         self.generated_token_logprobs.extend(batch_data.generated_token_logprobs)
         self.generated_top_logprobs.extend(batch_data.generated_top_logprobs)

--- a/dataquality/schemas/seq2seq.py
+++ b/dataquality/schemas/seq2seq.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Set, Tuple
 
@@ -101,3 +101,55 @@ class LogprobData:
 class ModelGeneration:
     generated_ids: np.ndarray
     generated_logprob_data: LogprobData
+
+
+@dataclass
+class BatchGenerationData:
+    """Dataclass for Generated Output Data
+
+    Stores the processed information from generated over a batch OR df
+    of text Inputs. Each parameter is a List of sample data with length
+    equal to the numer of samples currently in the BatchGenerationData
+    object.
+
+    Parameters:
+    -----------
+    generated_outputs: List[str]
+        The actual generated strings for each Input sample
+    generated_token_label_positions: List[List[Set[int]]]
+        Token label positions for each sample
+    generated_token_label_offsets: List[List[Tuple[int, int]]]
+        Token label positions for each sample
+    generated_token_logprobs: np.ndarray of shape - [seq_len]
+        Token label logprobs for each sample
+    top_logprobs: List[List[List[Tuple[str, float]]]]
+        top_logprobs for each sample
+    """
+    generated_outputs: List[str]
+    generated_token_label_positions: List[List[Set[int]]]
+    generated_token_label_offsets: List[List[Tuple[int, int]]]
+    generated_token_logprobs: List[np.ndarray]
+    generated_top_logprobs: List[List[List[Tuple[str, float]]]]
+
+    @classmethod
+    def empty_init(cls) -> 'BatchGenerationData':
+        """Initialize a BatchGenerationData object with no sample data"""
+        return cls(
+            generated_outputs=[],
+            generated_token_label_positions=[],
+            generated_token_label_offsets=[],
+            generated_token_logprobs=[],
+            generated_top_logprobs=[]
+        )
+
+    def extend_from(self, batch_data: "BatchGenerationData") -> None:
+        """Extend generation data from a new Batch
+
+        Note that we favor in-place combining of batches for improved
+        memory and performance.
+        """
+        self.generated_outputs.extend(batch_data.generated_outputs)
+        self.generated_token_label_positions.extend(batch_data.generated_token_label_positions)
+        self.generated_token_label_offsets.extend(batch_data.generated_token_label_offsets)
+        self.generated_token_logprobs.extend(batch_data.generated_token_logprobs)
+        self.generated_top_logprobs.extend(batch_data.generated_top_logprobs)

--- a/dataquality/schemas/seq2seq.py
+++ b/dataquality/schemas/seq2seq.py
@@ -126,15 +126,19 @@ class BatchGenerationData:
         Token label positions for each sample
     generated_token_logprobs: np.ndarray of shape - [seq_len]
         Token label logprobs for each sample
-    top_logprobs: List[List[List[Tuple[str, float]]]]
+    generated_top_logprobs: List[List[List[Tuple[str, float]]]]
         top_logprobs for each sample
     """
 
     generated_outputs: List[str] = field(default_factory=list)
     generated_token_label_positions: List[List[Set[int]]] = field(default_factory=list)
-    generated_token_label_offsets: List[List[Tuple[int, int]]] = field(default_factory=list)
+    generated_token_label_offsets: List[List[Tuple[int, int]]] = field(
+        default_factory=list
+    )
     generated_token_logprobs: List[np.ndarray] = field(default_factory=list)
-    generated_top_logprobs: List[List[List[Tuple[str, float]]]] = field(default_factory=list)
+    generated_top_logprobs: List[List[List[Tuple[str, float]]]] = field(
+        default_factory=list
+    )
 
     def extend_from(self, batch_data: "BatchGenerationData") -> None:
         """Extend generation data from a new Batch

--- a/dataquality/schemas/seq2seq.py
+++ b/dataquality/schemas/seq2seq.py
@@ -11,6 +11,8 @@ from vaex import DataFrame
 TOP_LOGPROBS_SCHEMA = pa.list_(pa.map_(pa.string(), pa.float32()))
 TOP_K = 5
 
+GENERATION_BATCH_SIZE = 1_000
+
 
 class Seq2SeqInputCols(str, Enum):
     id = "id"

--- a/dataquality/schemas/seq2seq.py
+++ b/dataquality/schemas/seq2seq.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Set, Tuple
 
@@ -130,22 +130,11 @@ class BatchGenerationData:
         top_logprobs for each sample
     """
 
-    generated_outputs: List[str]
-    generated_token_label_positions: List[List[Set[int]]]
-    generated_token_label_offsets: List[List[Tuple[int, int]]]
-    generated_token_logprobs: List[np.ndarray]
-    generated_top_logprobs: List[List[List[Tuple[str, float]]]]
-
-    @classmethod
-    def empty_init(cls) -> "BatchGenerationData":
-        """Initialize a BatchGenerationData object with no sample data"""
-        return cls(
-            generated_outputs=[],
-            generated_token_label_positions=[],
-            generated_token_label_offsets=[],
-            generated_token_logprobs=[],
-            generated_top_logprobs=[],
-        )
+    generated_outputs: List[str] = field(default_factory=list)
+    generated_token_label_positions: List[List[Set[int]]] = field(default_factory=list)
+    generated_token_label_offsets: List[List[Tuple[int, int]]] = field(default_factory=list)
+    generated_token_logprobs: List[np.ndarray] = field(default_factory=list)
+    generated_top_logprobs: List[List[List[Tuple[str, float]]]] = field(default_factory=list)
 
     def extend_from(self, batch_data: "BatchGenerationData") -> None:
         """Extend generation data from a new Batch

--- a/dataquality/utils/seq2seq/generation.py
+++ b/dataquality/utils/seq2seq/generation.py
@@ -208,7 +208,7 @@ def add_generated_output_to_df(
         Updated Dataframe with the generated columns added (see above)
     """
     model.eval()
-    generated_data = BatchGenerationData.empty_init()
+    generated_data = BatchGenerationData()
 
     for _, _, text_chunk in df.evaluate_iterator(
         S2SIC.text.value, chunk_size=GENERATION_BATCH_SIZE, parallel=False

--- a/dataquality/utils/seq2seq/generation.py
+++ b/dataquality/utils/seq2seq/generation.py
@@ -5,6 +5,7 @@ from transformers import GenerationConfig, PreTrainedModel, PreTrainedTokenizerF
 from vaex import DataFrame
 
 from dataquality.schemas.seq2seq import (
+    GENERATION_BATCH_SIZE,
     TOP_LOGPROBS_SCHEMA,
     BatchGenerationData,
     ModelGeneration,
@@ -210,7 +211,7 @@ def add_generated_output_to_df(
     generated_data = BatchGenerationData.empty_init()
 
     for _, _, text_chunk in df.evaluate_iterator(
-        S2SIC.text.value, chunk_size=100, parallel=False
+        S2SIC.text.value, chunk_size=GENERATION_BATCH_SIZE, parallel=False
     ):
         batch_generated_data = generate_on_batch(
             text_chunk, model, tokenizer, max_input_tokens, generation_config

--- a/tests/loggers/test_seq2seq.py
+++ b/tests/loggers/test_seq2seq.py
@@ -279,9 +279,6 @@ def test_add_generated_output_to_df(
         assert np.array_equal(logprobs, np.zeros(num_tokens) - 1)
         assert top_logprobs == [[("A", -1), ("B", -2)] for _ in range(num_tokens)]
 
-    # Make sure that we have removed the column left after flattening
-    assert not any([C.generation_data.value in col for col in df.get_column_names()])
-
 
 @patch("dataquality.utils.seq2seq.generation.process_sample_logprobs")
 @patch("dataquality.utils.seq2seq.generation.get_top_logprob_indices")

--- a/tests/loggers/test_seq2seq.py
+++ b/tests/loggers/test_seq2seq.py
@@ -17,9 +17,7 @@ from dataquality.loggers.logger_config.seq2seq import seq2seq_logger_config
 from dataquality.loggers.model_logger.seq2seq import Seq2SeqModelLogger
 from dataquality.schemas.seq2seq import (
     TOP_K,
-    AlignedTokenData,
-    LogprobData,
-    ModelGeneration, BatchGenerationData,
+    BatchGenerationData,
 )
 from dataquality.schemas.seq2seq import Seq2SeqOutputCols as C
 from dataquality.schemas.split import Split
@@ -226,7 +224,9 @@ def test_add_generated_output_to_df(
 
     num_tokens = 2
     mock_token_logprobs = [[-0.5, -0.1]] * batch_size
-    mock_top_logprobs = [[[("A", -1), ("B", -2)] for _ in range(num_tokens)]] * batch_size
+    mock_top_logprobs = [
+        [[("A", -1), ("B", -2)] for _ in range(num_tokens)]
+    ] * batch_size
 
     mock_generate_on_batch.return_value = BatchGenerationData(
         generated_outputs=mock_generated_outputs,
@@ -241,10 +241,10 @@ def test_add_generated_output_to_df(
     df_size = batch_size * num_batches
     df = vaex.from_dict({"text": ["Fake Input"] * df_size})
 
-    with patch("dataquality.utils.seq2seq.generation.GENERATION_BATCH_SIZE", batch_size):
-        df = add_generated_output_to_df(
-            df, Mock(), Mock(), 512, Mock()
-        )
+    with patch(
+        "dataquality.utils.seq2seq.generation.GENERATION_BATCH_SIZE", batch_size
+    ):
+        df = add_generated_output_to_df(df, Mock(), Mock(), 512, Mock())
 
     # Check the df columns!
     assert len(df) == df_size

--- a/tests/loggers/test_seq2seq.py
+++ b/tests/loggers/test_seq2seq.py
@@ -19,7 +19,7 @@ from dataquality.schemas.seq2seq import (
     TOP_K,
     AlignedTokenData,
     LogprobData,
-    ModelGeneration,
+    ModelGeneration, BatchGenerationData,
 )
 from dataquality.schemas.seq2seq import Seq2SeqOutputCols as C
 from dataquality.schemas.split import Split
@@ -197,86 +197,76 @@ def test_log_model_outputs(
         assert perplexity > 0
 
 
-@patch("dataquality.utils.seq2seq.generation.align_tokens_to_character_spans")
-@patch("dataquality.utils.seq2seq.generation.generate_sample_output")
+@patch("dataquality.utils.seq2seq.generation.generate_on_batch")
 def test_add_generated_output_to_df(
-    mock_generate_sample_output: Mock,
-    mock_align_tokens_to_character_spans: Mock,
+    mock_generate_on_batch: Mock,
 ) -> None:
-    """Test the complex vaex batched processing function for generation
+    """Test adding generation data to the df
+
+    The main logic to test here is adding data to vaex. We also test
+    the batched generation process.
+
+    Things to Test:
+        - Test that the correct df columns exist
+        - Test that we can handle batched generation.
 
     Things to Mock
-        - generate_sample_output: This can be fairly simple. The
-        one thing that we want to vary would be the length of things returned
-        - tokenizer: decode can be quite simple + encode
-        - model + generation_config: just to have as input params
-        - align_tokens_to_character_spans: This is already tested so let's just
-        mock the output!
-
-    What to test: Main thing to test is that the vaex format is all as expected.
-        - Test that each column has the correctly curated result
-        - Test that we don't have the extra column caused by vaex's flatten
+        - generate_on_batch: Create simple fake data for this
     """
-    # Mock the tokenizer
-    mock_tokenizer = MagicMock()
-    mock_tokenizer.decode.return_value = "Fake output"
-    mock_tokenizer.return_value = {"offset_mapping": []}
+    batch_size = 100
 
-    # Mock the model
-    mock_model = MagicMock()  # Don't actually need any functions for this
+    # Create mock generation data per batch
+    mock_generated_outputs = ["fake"] * batch_size
 
-    # Mock generation_config
-    mock_generation_config = MagicMock()
-
-    # Mock the generation process
-    def mock_generate_output() -> ModelGeneration:
-        """Create simple dummy ModelGeneration"""
-        # Generate fake outputs
-        num_fake_tokens = 4  # np.random.randint(3, 10)
-        gen_ids = np.arange(num_fake_tokens)
-        gen_token_logprobs = np.zeros(num_fake_tokens) - 1
-        gen_top_logprobs = [[("A", -1), ("B", -2)] for _ in range(num_fake_tokens)]
-        gen_logprob_data = LogprobData(
-            token_logprobs=gen_token_logprobs, top_logprobs=gen_top_logprobs
-        )
-        return ModelGeneration(gen_ids, gen_logprob_data)
-
-    mock_generate_sample_output.return_value = mock_generate_output()
-
-    # Mock aligned output for a single sample
-    fake_token_label_offsets = [[(0, 1), (1, 20), (20, 21), (21, 22), (22, 23)]]
     fake_token_label_positions = [[{0, 1}, {1}, {0}, {2, 3}, {3}]]
-    mock_align_tokens_to_character_spans.return_value = AlignedTokenData(
-        token_label_offsets=fake_token_label_offsets,
-        token_label_positions=fake_token_label_positions,
+    mock_token_label_positions = fake_token_label_positions * batch_size
+
+    fake_token_label_offsets = [[(0, 1), (1, 20), (20, 21), (21, 22), (22, 23)]]
+    mock_token_label_offsets = fake_token_label_offsets * batch_size
+
+    num_tokens = 2
+    mock_token_logprobs = [[-0.5, -0.1]] * batch_size
+    mock_top_logprobs = [[[("A", -1), ("B", -2)] for _ in range(num_tokens)]] * batch_size
+
+    mock_generate_on_batch.return_value = BatchGenerationData(
+        generated_outputs=mock_generated_outputs,
+        generated_token_label_positions=mock_token_label_positions,
+        generated_token_label_offsets=mock_token_label_offsets,
+        generated_token_logprobs=mock_token_logprobs,
+        generated_top_logprobs=mock_top_logprobs,
     )
 
     # Create fake df with vaex
-    df = vaex.from_dict({"text": ["Fake Input"] * 100})
+    num_batches = 10
+    df_size = batch_size * num_batches
+    df = vaex.from_dict({"text": ["Fake Input"] * df_size})
 
-    df = add_generated_output_to_df(
-        df, mock_model, mock_tokenizer, 512, mock_generation_config
-    )
-    # Make sure everything is in check!
-    assert len(df) == 100
-    assert df[C.generated_output.value].tolist() == ["Fake output"] * 100
-    # Convert to correct type
+    with patch("dataquality.utils.seq2seq.generation.GENERATION_BATCH_SIZE", batch_size):
+        df = add_generated_output_to_df(
+            df, Mock(), Mock(), 512, Mock()
+        )
+
+    # Check the df columns!
+    assert len(df) == df_size
+    assert df[C.generated_output.value].tolist() == mock_generated_outputs * num_batches
+    # Convert to correct type - this is because of the way vaex stores
+    # sets and tuples - i.e. they need to be lists
     fake_token_label_positions = [[list(val) for val in fake_token_label_positions[0]]]
     assert (
         df[C.generated_token_label_positions.value].tolist()
-        == fake_token_label_positions * 100
+        == fake_token_label_positions * num_batches * batch_size
     )
     fake_token_label_offsets = [[list(val) for val in fake_token_label_offsets[0]]]
     assert (
         df[C.generated_token_label_offsets.value].tolist()
-        == fake_token_label_offsets * 100
+        == fake_token_label_offsets * num_batches * batch_size
     )
     generated_token_logprobs = df[C.generated_token_logprobs.value].tolist()
     generated_top_logprobs = df[C.generated_top_logprobs.value].tolist()
     for logprobs, top_logprobs in zip(generated_token_logprobs, generated_top_logprobs):
         num_tokens = len(logprobs)
         assert num_tokens == len(top_logprobs)
-        assert np.array_equal(logprobs, np.zeros(num_tokens) - 1)
+        assert np.array_equal(logprobs, np.array([-0.5, -0.1]))
         assert top_logprobs == [[("A", -1), ("B", -2)] for _ in range(num_tokens)]
 
 

--- a/tests/utils/test_seq2seq_utils.py
+++ b/tests/utils/test_seq2seq_utils.py
@@ -140,7 +140,7 @@ def test_generate_sample_output(
     """
     # Mock the tokenizer
     mock_tokenizer = mock.MagicMock()
-    mock_tokenizer.return_value = {"input_ids": torch.tensor([[1, 2, 3, 0]])}
+    mock_tokenizer.return_value = {"input_ids": torch.tensor([[0, 2, 3, 1]])}
 
     # Mock the model
     mock_model = mock.MagicMock()


### PR DESCRIPTION
* [x] I have added tests to `tests` to cover my changes.
* [ ] I have updated `docs/`, if necessary.
* [ ] I have updated the `README.md`, if necessary.

***What existing issue does this pull request close?***

This PR address this [ticket](https://app.shortcut.com/galileo/story/7910)

***Bug Description***
Currently generation works with small dataset sizes, but fails when we try over > 500 samples. We get some very strange error related to the `StructArray` that we have to use. When I talked to Ben about this, he mentioned that while possible this vaex `StructArray` design was fairly temperamental and error prone - which it seems a might be. 

***Proposed Solution***
The primary reason to use a vaex register function is to avoid bringing large amounts of data into memory through lazy evaluation. However, as addressed by a previous issue, we end up effectively forcing the computation of the `generated_data` to avoid lazy recomputation. Therefore, we are not really using the vaex register function correctly.

With this in mind, we propose switching to a more manual batched processing of the generation job. This will give us more control over generation, especially around potential errors. We basically move to a manual batched approach using vaex's `.evaluate_iterator()`.

We introduce a new DataClass type called `BatchGenerationData`. This data class stores all the information needed for generation. Moreover, for batched processing we allow for initializing an empty central `generation_data` object, followed by easy *in-place* extending with a new batch of generation data. See this example:
```
generation_data = BatchGenerationData.empty_init()
for _ in range(num_batches):
  batch_generated_data = ...
  # Add new data to central data store
  generation_data.extend_from(batch_generated_data)
...
```

**Note**: We favor in-place adding of data for memory and performance concerns. 

