### PR TITLE
Bug/gen empty output

### DIFF
--- a/dataquality/utils/seq2seq/generation.py
+++ b/dataquality/utils/seq2seq/generation.py
@@ -79,9 +79,9 @@ def generate_sample_output(
     logits = model_outputs.logits
     logprobs = torch.nn.functional.log_softmax(logits, dim=-1).cpu().numpy()
 
-    # Remove singleton dimensions
-    logprobs = logprobs.squeeze()  # [seq_len, vocab_size]
-    gen_ids = gen_ids.squeeze().cpu().numpy()  # [seq_len]
+    # Remove singleton batch dimension
+    logprobs = logprobs.squeeze(0)  # [seq_len, vocab_size]
+    gen_ids = gen_ids.squeeze(0).cpu().numpy()  # [seq_len]
 
     top_logprobs_indices = get_top_logprob_indices(logprobs)
 

--- a/dataquality/utils/seq2seq/logprobs.py
+++ b/dataquality/utils/seq2seq/logprobs.py
@@ -142,10 +142,11 @@ def process_sample_logprobs(
         )
     sample_labels = sample_labels[..., None]
 
-    # Extract token_logprobs - shape [len(labels)]
+    # Extract token_logprobs return shape [len(labels), 1]
+    # Squeeze final dimension to get - shape [len(labels)]
     token_logprobs = np.take_along_axis(
         sample_logprobs, sample_labels, axis=-1
-    ).squeeze()
+    ).squeeze(-1)
 
     # Compute top_logprobs
     top_logprobs = extract_top_logprobs(sample_logprobs, sample_top_indices, tokenizer)

--- a/tests/utils/test_seq2seq_utils.py
+++ b/tests/utils/test_seq2seq_utils.py
@@ -104,9 +104,7 @@ def test_generate_sample_output(
 
 
 @mock.patch("dataquality.utils.seq2seq.generation.get_top_logprob_indices")
-def test_generate_sample_output_empty_sample(
-    mock_get_top_logprob_indices: mock.Mock
-):
+def test_generate_sample_output_empty_sample(mock_get_top_logprob_indices: mock.Mock):
     # Mock the tokenizer
     mock_tokenizer = mock.MagicMock()
     mock_tokenizer.return_value = {"input_ids": torch.tensor([[1, 2, 3, 0]])}

--- a/tests/utils/test_seq2seq_utils.py
+++ b/tests/utils/test_seq2seq_utils.py
@@ -60,7 +60,7 @@ def test_generate_sample_output(
         logits: torch.tensor
 
     # Mock model output and model device
-    mock_model.return_value = FakeOutput(torch.rand((1, 3, 20)))
+    mock_model.return_value = mock.MagicMock(logits=torch.rand((1, 3, 20)))
     mock_model.device = torch.device("cpu")
 
     # Mock generation_config
@@ -130,7 +130,7 @@ def test_generate_sample_output_empty_sample(mock_get_top_logprob_indices: mock.
         logits: torch.tensor
 
     # Mock model output and model device - shape (bs=1, seq_len=1, 20)
-    mock_model.return_value = FakeOutput(torch.rand((1, 1, 20)))
+    mock_model.return_value = mock.MagicMock(logits=torch.rand((1, 1, 20)))
     mock_model.device = torch.device("cpu")
 
     # Mock generation_config


### PR DESCRIPTION
* [x] I have added tests to `tests` to cover my changes.
* [ ] I have updated `docs/`, if necessary.
* [ ] I have updated the `README.md`, if necessary.

***What existing issue does this pull request close?***

Shortcut ticket: [link](https://app.shortcut.com/galileo/epic/5806?cf_workflow=500000005&ct_workflow=all&group_by=none&vc_group_by=day)

***Bug Description***
DQ logging fails when handling sequences of length one. This can happen for example in the case of an empty string with T5 where T5 represents the empty string as `input_ids = [1]` (i.e. just the `[EOS]` token). So e.g. during generation the model may immediately generate the `[EOS]` token leading, leading to a single token sequence.

***Root cause analysis***
This bug is a result of using the `.squeeze()` function without properly specifying dimensions. We use `.squeeze()` to remove singleton e.g. batch dimensions; however, when we have `seq_len=1`, `.squeeze()` will also remove this sequence dimension. See this example:
```
gen_ids = gen_ids[..., 1:] # Shape - (1, seq_len)
....
gen_ids = gen_ids.squeeze().cpu().numpy() # [seq_len]
```
If `seq_len = 1` then `gen_ids` will have  `shape = ()` rather than `(seq_len)`, since `squeeze()` removes all singleton dimensions. 

The fix that we add is that whenever we use squeeze we specify which dimension we specifically are squeezing! E.g.
```
gen_ids = gen_ids[..., 1:] # Shape - (1, seq_len)
....
# Squeeze the batch dimension
gen_ids = gen_ids.squeeze(0).cpu().numpy() # [seq_len]
```