### PR TITLE
Silencing tqdm during generation

### DIFF
--- a/dataquality/utils/seq2seq/generation.py
+++ b/dataquality/utils/seq2seq/generation.py
@@ -146,7 +146,9 @@ def generate_on_batch(
         generated_outputs.append(output)
         # Re-tokenize the data to get the token position offsets
         encoded_data = tokenizer([output], return_offsets_mapping=True)
-        aligned_data = align_tokens_to_character_spans(encoded_data["offset_mapping"])
+        aligned_data = align_tokens_to_character_spans(
+            encoded_data["offset_mapping"], disable_tqdm=True
+        )
         # aligned_data assumes batches, so for single samples it returns
         # batched list of length == 1.
         generated_token_label_positions.append(aligned_data.token_label_positions[0])

--- a/dataquality/utils/seq2seq/offsets.py
+++ b/dataquality/utils/seq2seq/offsets.py
@@ -170,13 +170,23 @@ def rollup_offset_mapping(
 
 
 def align_tokens_to_character_spans(
-    samples_offsets: List[List[Tuple[int, int]]]
+    samples_offsets: List[List[Tuple[int, int]]], disable_tqdm: bool = False
 ) -> AlignedTokenData:
-    """Iterates through each samples offsets and creates character-aligned spans"""
+    """Iterates through each samples offsets and creates character-aligned spans
+
+    Parameters:
+    -----------
+    disable_tqdm: bool
+        Flag for disabling tqdm. Used generally when we are calling
+        align_tokens_to_character_spans over small (e.g. 1 sample) batches
+    """
     all_offsets = []
     all_token_positions = []
     for offset_mapping in tqdm(
-        samples_offsets, leave=False, desc="Aligning characters with tokens"
+        samples_offsets,
+        leave=False,
+        desc="Aligning characters with tokens",
+        disable=disable_tqdm,
     ):
         offsets, token_positions = rollup_offset_mapping(offset_mapping)
         all_offsets.append(offsets)


### PR DESCRIPTION
* [ ] I have added tests to `tests` to cover my changes.
* [ ] I have updated `docs/`, if necessary.
* [ ] I have updated the `README.md`, if necessary.

***Description***
This is a very small PR addressing a bug/annoyance when generating in `dq.finish()`. Essentially, during generation we rely no the function `align_tokens_to_character_spans` to create token alignment data. We do this at a per-sample level, since that is how we do generation. However, the `align_tokens_to_character_spans` function was initially developed as a batch processing methods. And with this, we use tqdm.

This becomes annoying when processing at the sample level because we constantly display `tqdm` for just a single iteration loop. See the demonstration bellow.

***Demonstration***

Constantly re-running `tqdm` with a single sample leads to this annoying flickering on the DQ side.

https://github.com/rungalileo/dataquality/assets/29869344/88536639-b9e1-4071-a781-74f147fdf18e


***Solution***

We basically just turn of `tqdm` when generation. Here is the result!

https://github.com/rungalileo/dataquality/assets/29869344/94d36180-7e23-492a-b85e-ac7e8e414209
