### PR TITLE
fix(internal): rename project endpoint

### DIFF
--- a/dataquality/clients/api.py
+++ b/dataquality/clients/api.py
@@ -160,6 +160,16 @@ class ApiClient:
         run = self.make_request(RequestType.PUT, url=url, body=data)
         return run if run else {}
 
+    def update_project_name(self, project_name: str, new_name: str) -> Dict:
+        proj = self.get_project_by_name(project_name)
+        if not proj:
+            raise GalileoException(f"No project with name {project_name}")
+
+        url = f"{config.api_url}/{Route.projects}/{proj['id']}"
+        data = {"name": new_name}
+        proj_resp = self.make_request(RequestType.PUT, url=url, body=data)
+        return proj_resp if proj_resp else {}
+
     def create_project(self, project_name: str, is_public: bool = False) -> Dict:
         """Creates a project given a name and returns the project information"""
         body = {"name": project_name, "is_public": is_public}

--- a/dataquality/internal.py
+++ b/dataquality/internal.py
@@ -98,3 +98,19 @@ def rename_run(project_name: str, run_name: str, new_name: str) -> None:
         f"Successfully renamed run {project_name}/{run_name} to "
         f"{project_name}/{new_name}"
     )
+
+
+def rename_project(project_name: str, new_name: str) -> None:
+    """Renames a project
+
+    Useful if a project was named incorrectly, or if a project was created with a
+    temporary name and needs to be renamed to something more permanent
+
+    :param project_name: The name of the project
+    :param new_name: The new name to assign to the project
+    """
+    api_client.update_project_name(project_name, new_name)
+    print(
+        f"Successfully renamed project {project_name} to "
+        f"{new_name}"
+    )


### PR DESCRIPTION
small PR to allow renaming a project from the client for internal use only 