### PR TITLE
Free GPU Memory Before `dq.finish()` in `auto()`

### DIFF
--- a/dataquality/integrations/seq2seq/s2s_trainer.py
+++ b/dataquality/integrations/seq2seq/s2s_trainer.py
@@ -251,6 +251,6 @@ def do_train(
                 logits = outputs.logits  # Shape - [bs, bs_seq_ln, vocab]
                 dq.log_model_outputs(logits=logits, ids=ids)
 
-    cleanup_cuda(optimizer, batch, outputs)
+    cleanup_cuda(optimizer, [batch, outputs])
     dq.finish(wait=wait, create_data_embs=create_data_embs)
     return model

--- a/dataquality/integrations/seq2seq/s2s_trainer.py
+++ b/dataquality/integrations/seq2seq/s2s_trainer.py
@@ -1,3 +1,4 @@
+import gc
 from typing import Dict, List, Optional, Tuple
 
 import torch
@@ -249,6 +250,14 @@ def do_train(
                 outputs = model(**batch)
                 logits = outputs.logits  # Shape - [bs, bs_seq_ln, vocab]
                 dq.log_model_outputs(logits=logits, ids=ids)
+
+    # Delete unused variables to free CUDA memory to ensure that
+    # dq.finish() does not run into out-of-memory errors.
+    del optimizer  # This is the most important!
+    del batch
+    del outputs
+    torch.cuda.empty_cache()
+    gc.collect()
 
     dq.finish(wait=wait, create_data_embs=create_data_embs)
     return model

--- a/dataquality/integrations/seq2seq/s2s_trainer.py
+++ b/dataquality/integrations/seq2seq/s2s_trainer.py
@@ -253,6 +253,6 @@ def do_train(
 
     # Cleanup all unused data on the GPU and any references
     # to that data
-    cleanup_cuda(optimizer, [batch, outputs])
+    cleanup_cuda(optimizer, [logits, loss, batch, outputs])
     dq.finish(wait=wait, create_data_embs=create_data_embs)
     return model

--- a/dataquality/utils/torch.py
+++ b/dataquality/utils/torch.py
@@ -28,17 +28,18 @@ from dataquality.utils.helpers import wrap_fn
 from dataquality.utils.patcher import Borg, Patch, PatchManager
 
 
-def cleanup_cuda(
-    optimizer: Optimizer, batch: torch.Tensor, outputs: torch.Tensor
-) -> None:
+def cleanup_cuda(optimizer: Optional[Optimizer], tensors: List[torch.Tensor]) -> None:
     """Cleanup cuda memory
 
     Delete unused variables to free CUDA memory to ensure that
     dq.finish() does not run into out-of-memory errors.
     """
-    del optimizer
-    del batch
-    del outputs
+    if optimizer:
+        del optimizer
+
+    for tensor in tensors:
+        if torch.is_tensor(tensor):
+            del tensor
 
     torch.cuda.empty_cache()
     gc.collect()

--- a/dataquality/utils/torch.py
+++ b/dataquality/utils/torch.py
@@ -11,6 +11,7 @@ import numpy as np  # noqa: F401
 import torch
 from torch import Tensor
 from torch.nn import Module
+from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 from torch.utils.data.dataloader import (
     _BaseDataLoaderIter,
@@ -27,14 +28,17 @@ from dataquality.utils.helpers import wrap_fn
 from dataquality.utils.patcher import Borg, Patch, PatchManager
 
 
-def cleanup_cuda(*args: Tuple) -> None:
+def cleanup_cuda(
+    optimizer: Optimizer, batch: torch.Tensor, outputs: torch.Tensor
+) -> None:
     """Cleanup cuda memory
 
     Delete unused variables to free CUDA memory to ensure that
     dq.finish() does not run into out-of-memory errors.
     """
-    for arg in args:
-        del arg
+    del optimizer
+    del batch
+    del outputs
 
     torch.cuda.empty_cache()
     gc.collect()

--- a/dataquality/utils/torch.py
+++ b/dataquality/utils/torch.py
@@ -27,6 +27,19 @@ from dataquality.utils.helpers import wrap_fn
 from dataquality.utils.patcher import Borg, Patch, PatchManager
 
 
+def cleanup_cuda(*args: Tuple) -> None:
+    """Cleanup cuda memory
+
+    Delete unused variables to free CUDA memory to ensure that
+    dq.finish() does not run into out-of-memory errors.
+    """
+    for arg in args:
+        del arg
+
+    torch.cuda.empty_cache()
+    gc.collect()
+
+
 class ModelHookManager(Borg):
     """
     Manages hooks for models. Has the ability to find the layer automatically.


### PR DESCRIPTION
* [ ] I have added tests to `tests` to cover my changes.
* [ ] I have updated `docs/`, if necessary.
* [ ] I have updated the `README.md`, if necessary.

***What existing issue does this pull request close?***

This PR helps prevent potential `CUDA` memory errors in `dq.auto()`. After training, `dq.finish()` uses some additional `GPU` memory for computing embeddings and for generation. If after training, there is very little available GPU RAM, we can run into big trouble!

Thankfully though, after training is complete, a lot of memory / data on the GPU is no longer needed for `dq.finish()`. For example, a big memory "hog" is the `optimizer`, which for many optimizers, effectively stores multiple copies of the entire model weights. 

To reclaim / free unused GPU memory, and pretty much safely ensure that `dq.finish()` will not error out we use the following pattern:
```
del  optimizer
...
torch.cuda.empty_cache()
import gc
gc.collect()
```

***Demonstration***

To give a bit of additional context into how much this actually saves, here are some rough numbers:

I was training a `flan-t5-small` model with `batch_size=8`. At the end of training / during training I was pretty consistently using around `7.7GB` of GPU RAM.

After freeing unused variables e.g. `optimizer, batch, and outputs`, we went down to `~3.5GB` of GPU RAM. Massive savings!!

To round out the example, when calling `dq.finish()` the GPU RAM usage goes back up to `~4.4GB`. 

So overall, we see that freeing unused variables effectively makes up for all of the additional memory used during `dq.finish()`. Moreover, we emphasize how important this is, since even the small model uses `7.7GB` of memory during training and an additional `<1GB` during `.finis()`! Often people will push their training right to the memory limit (testing out different batch sizes to find the sweet spot), so even if `dq.finish()` only uses `<1GB` memory, we can definitely run into issues.