### PR TITLE
fix: s2s auto local file support

### DIFF
--- a/dataquality/dq_auto/base_data_manager.py
+++ b/dataquality/dq_auto/base_data_manager.py
@@ -128,6 +128,7 @@ class BaseDatasetManager:
         self,
         hf_data: Optional[Union[DatasetDict, str]] = None,
         train_data: Optional[Union[pd.DataFrame, Dataset, str]] = None,
+        train_path: Optional[str] = None,
     ) -> Optional[DatasetDict]:
         """Tries to load the DatasetDict if available
 

--- a/dataquality/dq_auto/base_data_manager.py
+++ b/dataquality/dq_auto/base_data_manager.py
@@ -128,7 +128,6 @@ class BaseDatasetManager:
         self,
         hf_data: Optional[Union[DatasetDict, str]] = None,
         train_data: Optional[Union[pd.DataFrame, Dataset, str]] = None,
-        train_path: Optional[str] = None,
     ) -> Optional[DatasetDict]:
         """Tries to load the DatasetDict if available
 

--- a/dataquality/dq_auto/schema.py
+++ b/dataquality/dq_auto/schema.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional, Union
 
-from dataquality.dq_auto.schema import BaseAutoDatasetConfig, BaseAutoTrainingConfig
+import pandas as pd
+from datasets import Dataset, DatasetDict
 
 
 @dataclass
-class Seq2SeqDatasetConfig(BaseAutoDatasetConfig):
+class BaseAutoDatasetConfig:
     """Configuration for creating a dataset from a file or object
 
     One of `hf_name`, `train_path` or `train_dataset` should be provided. If none of
@@ -33,49 +34,45 @@ class Seq2SeqDatasetConfig(BaseAutoDatasetConfig):
     :param target_col: Column name for target data, defaults to "label"
     """
 
-    pass
+    hf_data: Optional[Union[DatasetDict, str]] = None
+    # If dataset provided as path to local file
+    train_path: Optional[str] = None
+    val_path: Optional[str] = None
+    test_path: Optional[str] = None
+    # If dataset provided as object
+    train_data: Optional[Union[pd.DataFrame, Dataset]] = None
+    val_data: Optional[Union[pd.DataFrame, Dataset]] = None
+    test_data: Optional[Union[pd.DataFrame, Dataset]] = None
+    # Column names
+    input_col: str = "text"
+    target_col: str = "label"
+
+    def __post_init__(self) -> None:
+        if not any([self.hf_data, self.train_path, self.train_data]):
+            raise ValueError(
+                "One of hf_data, train_path, or train_data must be provided."
+                "To use a random demo dataset in `auto`, set dataset_config to None."
+            )
 
 
 @dataclass
-class Seq2SeqTrainingConfig(BaseAutoTrainingConfig):
-    """Configuration for training a seq2seq model
+class BaseAutoTrainingConfig:
+    """Configuration for training a HuggingFace model
+
+    Base config values are based on auto with Text Classification. Can be overridden
+    by parent class for each modality.
 
     :param model: The pretrained AutoModel from huggingface that will be used to
         tokenize and train on the provided data. Default google/flan-t5-base
-    :param epochs: Optional num training epochs. If not set, we default to 3
+    :param epochs: Optional num training epochs. If not set, we default to 15
     :param learning_rate: Optional learning rate. If not set, we default to 3e-4
-    :param accumulation_steps: Optional accumulation steps. If not set, we default to 4
     :param batch_size: Optional batch size. If not set, we default to 4
     :param create_data_embs: Whether to create data embeddings for this run. If set to
         None, data embeddings will be created only if a GPU is available
-    :param max_input_tokens: Optional max input tokens. If not set, we default to 512
-    :param max_target_tokens: Optional max target tokens. If not set, we default to 128
     """
 
-    # Overwrite base values
-    model: str = "google/flan-t5-base"
-    epochs: int = 3
-    # Custom Seq2Seq values
-    accumulation_steps: int = 4
-    max_input_tokens: int = 512
-    max_target_tokens: int = 128
-
-
-@dataclass
-class Seq2SeqGenerationConfig:
-    """Configuration for generating insights from a trained seq2seq model
-
-    We use the default values in HF GenerationConfig
-    See more about the parameters here:
-    https://huggingface.co/docs/transformers/v4.30.0/en/main_classes/text_generation#transformers.GenerationConfig
-
-    :param generation_splits: Optional list of splits to generate on. If not set, we
-        default to ["test"]
-    """
-
-    max_new_tokens: int = 16
-    temperature: float = 0.2
-    do_sample: bool = False  # Whether we use multinomial sampling
-    top_p: float = 1.0
-    top_k: int = 50
-    generation_splits: Optional[List[str]] = None
+    model: str = "distilbert-base-uncased"
+    epochs: int = 15
+    learning_rate: float = 3e-4
+    batch_size: int = 4
+    create_data_embs: Optional[bool] = None

--- a/dataquality/dq_auto/schema.py
+++ b/dataquality/dq_auto/schema.py
@@ -63,7 +63,7 @@ class BaseAutoTrainingConfig:
     by parent class for each modality.
 
     :param model: The pretrained AutoModel from huggingface that will be used to
-        tokenize and train on the provided data. Default google/flan-t5-base
+        tokenize and train on the provided data. Default distilbert-base-uncased
     :param epochs: Optional num training epochs. If not set, we default to 15
     :param learning_rate: Optional learning rate. If not set, we default to 3e-4
     :param batch_size: Optional batch size. If not set, we default to 4

--- a/dataquality/integrations/seq2seq/auto.py
+++ b/dataquality/integrations/seq2seq/auto.py
@@ -1,5 +1,5 @@
 from random import choice
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from datasets import Dataset, DatasetDict, load_dataset
 from transformers import Trainer
@@ -97,28 +97,18 @@ class S2SDatasetManager(BaseDatasetManager):
         dd = dd or DatasetDict()
 
         if not dd:
-            col_mapping: Dict[str, str] = {}
-            # dataset_config.input_col: "text",
-            # dataset_config.target_col: "label",
-            # }
             train_data = dataset_config.train_path or dataset_config.train_data
-            # We don't need to check for train because `try_load_dataset_dict` validates
-            # that it exists already. One of hf_data or train_data must exist
-            dd[Split.train] = self._convert_to_hf_dataset(
-                train_data, column_mapping=col_mapping
-            )
+            # We don't need to check for train data in dd because
+            # `try_load_dataset_dict_from_config` validates that it exists already
+            dd[Split.train] = self._convert_to_hf_dataset(train_data)
 
             val_data = dataset_config.val_path or dataset_config.val_data
             if val_data is not None:
-                dd[Split.validation] = self._convert_to_hf_dataset(
-                    val_data, column_mapping=col_mapping
-                )
+                dd[Split.validation] = self._convert_to_hf_dataset(val_data)
 
             test_data = dataset_config.test_path or dataset_config.test_data
             if test_data is not None:
-                dd[Split.test] = self._convert_to_hf_dataset(
-                    test_data, column_mapping=col_mapping
-                )
+                dd[Split.test] = self._convert_to_hf_dataset(test_data)
 
         return self._validate_dataset_dict(dd, []), dataset_config
 

--- a/dataquality/integrations/seq2seq/auto.py
+++ b/dataquality/integrations/seq2seq/auto.py
@@ -140,7 +140,8 @@ class S2SDatasetManager(BaseDatasetManager):
         for key in list(clean_dd.keys()):
             ds = clean_dd.pop(key)
             # TODO: temporary, update
-            ds = ds.select(range(100))
+            if ds.num_rows > 100:
+                ds = ds.select(range(100))
 
             if "id" not in ds.features:
                 ds = ds.add_column("id", list(range(ds.num_rows)))

--- a/dataquality/integrations/seq2seq/auto.py
+++ b/dataquality/integrations/seq2seq/auto.py
@@ -55,6 +55,7 @@ class S2SDatasetManager(BaseDatasetManager):
             "If this is just a Dataset, pass it to `train_data`"
         )
         if dataset_config.hf_data:
+            hf_data = dataset_config.hf_data
             if isinstance(hf_data, str):
                 dd = load_dataset(hf_data)
                 self.formatter = get_formatter(hf_data)

--- a/dataquality/integrations/seq2seq/s2s_trainer.py
+++ b/dataquality/integrations/seq2seq/s2s_trainer.py
@@ -20,8 +20,8 @@ from transformers import (
 import dataquality as dq
 from dataquality.integrations.seq2seq.hf import watch
 from dataquality.integrations.seq2seq.schema import (
-    AutoGenerationConfig,
-    AutoTrainingConfig,
+    Seq2SeqGenerationConfig,
+    Seq2SeqTrainingConfig,
 )
 from dataquality.schemas.split import Split
 from dataquality.utils.torch import cleanup_cuda
@@ -80,8 +80,8 @@ def get_trainer(
     dd: DatasetDict,
     input_col: str,
     target_col: str,
-    training_config: AutoTrainingConfig,
-    generation_config: AutoGenerationConfig,
+    training_config: Seq2SeqTrainingConfig,
+    generation_config: Seq2SeqGenerationConfig,
 ) -> Tuple[PreTrainedModel, Dict[str, DataLoader]]:
     """Sets up the model and tokenizer for training
 
@@ -144,7 +144,7 @@ def get_trainer(
 def do_train(
     model: PreTrainedModel,
     dataloaders: Dict[str, torch.utils.data.DataLoader],
-    training_config: AutoTrainingConfig,
+    training_config: Seq2SeqTrainingConfig,
     wait: bool,
 ) -> Trainer:
     # training and evaluation

--- a/dataquality/integrations/seq2seq/schema.py
+++ b/dataquality/integrations/seq2seq/schema.py
@@ -33,8 +33,6 @@ class Seq2SeqDatasetConfig(BaseAutoDatasetConfig):
     :param target_col: Column name for target data, defaults to "label"
     """
 
-    pass
-
 
 @dataclass
 class Seq2SeqTrainingConfig(BaseAutoTrainingConfig):

--- a/dataquality/utils/auto.py
+++ b/dataquality/utils/auto.py
@@ -32,6 +32,9 @@ def load_data_from_str(data: str) -> Union[pd.DataFrame, Dataset]:
             f"DatasetDict, consider passing it to `hf_data` (dq.auto(hf_data=data))"
         )
         return ds
+    elif ext == ".jsonl":
+        # If it's a jsonl file, we load it as a pandas dataframe
+        return pd.read_json(data, lines=True)
     else:
         # .csv -> read_csv, .parquet -> read_parquet
         func = f"read_{ext.lstrip('.')}"

--- a/docs/notebooks/Seq2Seq-Auto.ipynb
+++ b/docs/notebooks/Seq2Seq-Auto.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "from dataquality.integrations.seq2seq.auto import auto\n",
-    "from dataquality.integrations.seq2seq.schema import Seq2SeqDatasetConfig"
+    "from dataquality.integrations.seq2seq.schema import Seq2SeqDatasetConfig, Seq2SeqGenerationConfig"
    ]
   },
   {
@@ -36,7 +36,7 @@
     "    hf_data=\"tatsu-lab/alpaca\"\n",
     ")\n",
     "\n",
-    "auto(run_name=\"hi\", dataset_config=hf_dataset_config)"
+    "auto(run_name=\"alpaca\", dataset_config=hf_dataset_config)"
    ]
   },
   {
@@ -44,45 +44,17 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "hf_dataset_config = Seq2SeqDatasetConfig(\n",
-    "    train_path=\"./prompt_completion.jsonl\",\n",
-    "    input_col=\"prompt\",\n",
-    "    target_col=\"completion\",\n",
-    ")\n",
+    "# dataset_config = Seq2SeqDatasetConfig(\n",
+    "#     train_path=\"./prompt_completion.jsonl\",\n",
+    "#     input_col=\"prompt\",\n",
+    "#     target_col=\"completion\",\n",
+    "# )\n",
+    "# gen_config = Seq2SeqGenerationConfig(\n",
+    "#     generation_splits=[\"training\", \"validation\", \"test\"]\n",
+    "# )\n",
     "\n",
-    "auto(run_name=\"hi\", dataset_config=hf_dataset_config)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd    \n",
-    "jsonObj = pd.read_json(path_or_buf=\"chat.jsonl\", lines=True)"
+    "# auto(run_name=\"with_gen\", dataset_config=dataset_config, generation_config=gen_config)"
    ]
   },
   {

--- a/docs/notebooks/Seq2Seq-Auto.ipynb
+++ b/docs/notebooks/Seq2Seq-Auto.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "from dataquality.integrations.seq2seq.auto import auto\n",
-    "from dataquality.integrations.seq2seq.schema import Seq2SeqDatasetConfig, Seq2SeqGenerationConfig"
+    "from dataquality.integrations.seq2seq.schema import Seq2SeqDatasetConfig"
    ]
   },
   {
@@ -18,9 +18,9 @@
    "source": [
     "import os\n",
     "\n",
-    "# os.environ['GALILEO_CONSOLE_URL']=\"http://localhost:8088\"\n",
-    "# os.environ[\"GALILEO_USERNAME\"]=\"user@example.com\"\n",
-    "# os.environ[\"GALILEO_PASSWORD\"]=\"Th3secret_\"\n",
+    "os.environ['GALILEO_CONSOLE_URL']=\"\"\n",
+    "os.environ[\"GALILEO_USERNAME\"]=\"\"\n",
+    "os.environ[\"GALILEO_PASSWORD\"]=\"\"\n",
     "\n",
     "import dataquality as dq\n",
     "dq.configure()"
@@ -32,29 +32,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf_dataset_config = Seq2SeqDatasetConfig(\n",
-    "    hf_data=\"tatsu-lab/alpaca\"\n",
+    "from dataquality.integrations.seq2seq.schema import Seq2SeqGenerationConfig, Seq2SeqTrainingConfig\n",
+    "\n",
+    "dataset_config = Seq2SeqDatasetConfig(\n",
+    "    train_path=\"./path_to_training.jsonl\",\n",
+    "    test_path=\"./path_to_test.jsonl\",\n",
+    "    input_col=\"prompt\",\n",
+    "    target_col=\"completion\",\n",
+    ")\n",
+    "gen_config = Seq2SeqGenerationConfig(\n",
+    "    generation_splits=[\"training\", \"validation\", \"test\"]\n",
+    ")\n",
+    "tr_config = Seq2SeqTrainingConfig(\n",
+    "    max_target_tokens=256,\n",
     ")\n",
     "\n",
-    "auto(run_name=\"alpaca\", dataset_config=hf_dataset_config)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# dataset_config = Seq2SeqDatasetConfig(\n",
-    "#     train_path=\"./prompt_completion.jsonl\",\n",
-    "#     input_col=\"prompt\",\n",
-    "#     target_col=\"completion\",\n",
-    "# )\n",
-    "# gen_config = Seq2SeqGenerationConfig(\n",
-    "#     generation_splits=[\"training\", \"validation\", \"test\"]\n",
-    "# )\n",
-    "\n",
-    "# auto(run_name=\"with_gen\", dataset_config=dataset_config, generation_config=gen_config)"
+    "auto(run_name=\"my_s2s_run\", dataset_config=dataset_config, generation_config=gen_config, training_config=tr_config)"
    ]
   },
   {

--- a/docs/notebooks/Seq2Seq-Auto.ipynb
+++ b/docs/notebooks/Seq2Seq-Auto.ipynb
@@ -6,7 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dataquality.integrations.seq2seq.auto import auto"
+    "from dataquality.integrations.seq2seq.auto import auto\n",
+    "from dataquality.integrations.seq2seq.schema import Seq2SeqDatasetConfig"
    ]
   },
   {
@@ -17,10 +18,9 @@
    "source": [
     "import os\n",
     "\n",
-    "os.environ['GALILEO_CONSOLE_URL']=\"http://localhost:8088\"\n",
-    "os.environ[\"GALILEO_USERNAME\"]=\"user@example.com\"\n",
-    "os.environ[\"GALILEO_PASSWORD\"]=\"Th3secret_\"\n",
-    "\n",
+    "# os.environ['GALILEO_CONSOLE_URL']=\"http://localhost:8088\"\n",
+    "# os.environ[\"GALILEO_USERNAME\"]=\"user@example.com\"\n",
+    "# os.environ[\"GALILEO_PASSWORD\"]=\"Th3secret_\"\n",
     "\n",
     "import dataquality as dq\n",
     "dq.configure()"
@@ -32,9 +32,41 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DATASET = \"tatsu-lab/alpaca\"\n",
-    "auto(DATASET)"
+    "hf_dataset_config = Seq2SeqDatasetConfig(\n",
+    "    hf_data=\"tatsu-lab/alpaca\"\n",
+    ")\n",
+    "\n",
+    "auto(run_name=\"hi\", dataset_config=hf_dataset_config)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hf_dataset_config = Seq2SeqDatasetConfig(\n",
+    "    train_path=\"./prompt_completion.jsonl\",\n",
+    "    input_col=\"prompt\",\n",
+    "    target_col=\"completion\",\n",
+    ")\n",
+    "\n",
+    "auto(run_name=\"hi\", dataset_config=hf_dataset_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/8104/dq-auto-improvements-jsonl-file-support

While creating this PR, I realized there are a ton of places we can improve the other `auto` flows by using these schema configs. While we aren't making that refactor now, we are setting up the stage by creating base config schema here. 

In this PR we:
- Create base schema configs in `dataquality/dq_auto/schema.py`
- Create the Seq2Seq schema in `dataquality/integrations/seq2seq/schema.py`
- Extend `S2SDatasetManager` to load datasets from the config object (note this can go in the Base Manager in the future)
- Update the example notebook to use schema with an example for hf_data and an example with a local dataset