### PR TITLE
fix: history chat

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/integrations/seq2seq/formatters/chat.py
+++ b/dataquality/integrations/seq2seq/formatters/chat.py
@@ -184,6 +184,12 @@ class ChatHistoryFormatter(ChatFormatter):
             parsed_history = self.tokenizer.decode(
                 history_tokens, skip_special_tokens=True
             )
-            user_inputs[i] = parsed_history.replace(NEWLINE_TOKEN, NEWLINE_CHAR)
+            parsed_history = parsed_history.replace(NEWLINE_TOKEN, NEWLINE_CHAR)
+            # We don't want to have the input start mid turn, so we find the first
+            # instance of the user or assistant role and start there
+            first_user_index = parsed_history.find(f"{self.user}: ")
+            first_assistant_index = parsed_history.find(f"{self.assistant}: ")
+            start_index = min(first_user_index, first_assistant_index)
+            user_inputs[i] = parsed_history[start_index:]
 
         return formatted_sample

--- a/dataquality/integrations/seq2seq/formatters/chat.py
+++ b/dataquality/integrations/seq2seq/formatters/chat.py
@@ -66,7 +66,7 @@ class ChatFormatter(BaseFormatter):
             if k not in [self.metadata_col, self.turns_col, "id"]:
                 metadata[k] = v
 
-        turn_data: Dict[str, Any] = {"turn_id": None, "chat_id": None}
+        turn_data: Dict[str, Any] = {"chat_id": None, "turn_id": None}
         turn_id = 1
         turn_default_cols = [self.role_col, self.content_col]
         for turn in turns:

--- a/dataquality/integrations/seq2seq/formatters/chat.py
+++ b/dataquality/integrations/seq2seq/formatters/chat.py
@@ -130,7 +130,7 @@ class ChatHistoryFormatter(ChatFormatter):
     ) -> Dict[str, Any]:
         """Formats a chat dataset for seq2seq with previous turn history
 
-        Similair to ChatFormatter, except subsequent turns contain
+        Similar to ChatFormatter, except subsequent turns contain
         context from previous turns.
 
         Example:


### PR DESCRIPTION
Follow up of https://github.com/rungalileo/dataquality/pull/779 to support having history in the chat of previous turns

Builds off of Jon's work here: https://colab.research.google.com/drive/1O5v41k-sMTBxTVqQCAkDuA8q5RX3qLZL?authuser=2#scrollTo=RhqLFpEPq2sI

Demo run: https://console.dev.rungalileo.io/insights/a29cfac8-773d-45f2-aaac-adfd61fe6ef5/201fc929-63be-4341-82e6-a694900719dc?dataframeColumns=chat_id%3B%26data_error_potential%3B%26input%3B%26perplexity%3B%26project_name%3B%26target%3B%26turn_id&metaFilter=chat_id%3A5&sortBy=turn_id&sortDirection=asc&taskType=8