### PR TITLE
fix: pandas df truthiness

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.1.6"
+__version__ = "1.1.7"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/dq_auto/schema.py
+++ b/dataquality/dq_auto/schema.py
@@ -55,7 +55,13 @@ class BaseAutoDatasetConfig:
     formatter: BaseFormatter = field(default_factory=DefaultFormatter)
 
     def __post_init__(self) -> None:
-        if not any([self.hf_data, self.train_path, self.train_data]):
+        if not any(
+            [
+                self.hf_data is not None,
+                self.train_path is not None,
+                self.train_data is not None,
+            ]
+        ):
             raise ValueError(
                 "One of hf_data, train_path, or train_data must be provided."
                 "To use a random demo dataset in `auto`, set dataset_config to None."


### PR DESCRIPTION
```python
>>> bool(dataset)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
[<ipython-input-9-c57750f91409>](https://localhost:8080/#) in <cell line: 1>()
----> 1 bool(dataset)

[/usr/local/lib/python3.10/dist-packages/pandas/core/generic.py](https://localhost:8080/#) in __nonzero__(self)
   1525     @final
   1526     def __nonzero__(self) -> NoReturn:
-> 1527         raise ValueError(
   1528             f"The truth value of a {type(self).__name__} is ambiguous. "
   1529             "Use a.empty, a.bool(), a.item(), a.any() or a.all()."

ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```