### PR TITLE
Seq2Seq: Only (force-)add val data if we fine-tune

### DIFF
--- a/dataquality/integrations/seq2seq/s2s_trainer.py
+++ b/dataquality/integrations/seq2seq/s2s_trainer.py
@@ -194,7 +194,7 @@ def do_train(
     )  # simply defining the context, setting the type is to make the linter happy
 
     # If skip_train=True, we add 1 epoch so we can do inference and still log the data
-    for epoch in range(training_config.epochs + bool(skip_train)):
+    for epoch in range(training_config.epochs + int(skip_train)):
         dq.set_epoch_and_split(split=Split.train, epoch=epoch)
         model.eval() if skip_train else model.train()
         train_epoch_loss = 0.0


### PR DESCRIPTION
Continuing https://app.shortcut.com/galileo/story/8588/dq-seq2seq-auto-with-0-epochs-just-pass-over-data-no-backwards

Succesfully tested with run https://console.dev.rungalileo.io/insights/e24eb571-8eaf-45a1-beb0-86c6488f4f1a/44cc2011-1bfb-48f6-8746-4a1eae8b61d4?dataframeColumns=data_error_potential%3B%26input%3B%26instruction%3B%26perplexity%3B%26target&taskType=8

![Screenshot 2023-11-01 at 10 39 40 AM](https://github.com/rungalileo/dataquality/assets/112427971/5fe675b2-a9a5-4ce9-92b5-d61cceb92d29)
