### PR TITLE
fix: remove unused labels

### DIFF
--- a/dataquality/core/log.py
+++ b/dataquality/core/log.py
@@ -364,7 +364,6 @@ def log_model_outputs(
     probs: Optional[Union[List, np.ndarray]] = None,
     inference_name: Optional[str] = None,
     exclude_embs: bool = False,
-    labels: Optional[np.ndarray] = None,
 ) -> None:
     """Logs model outputs for model during training/test/validation.
 
@@ -407,7 +406,6 @@ def log_model_outputs(
         logits=logits.astype(np.float32) if isinstance(logits, np.ndarray) else logits,
         probs=probs.astype(np.float32) if isinstance(probs, np.ndarray) else probs,
         inference_name=inference_name,
-        labels=labels.astype(np.float32) if isinstance(labels, np.ndarray) else labels,
     )
     model_logger.log()
 

--- a/dataquality/loggers/model_logger/base_model_logger.py
+++ b/dataquality/loggers/model_logger/base_model_logger.py
@@ -33,7 +33,6 @@ class BaseGalileoModelLogger(BaseGalileoLogger):
         split: str = "",
         epoch: Optional[int] = None,
         inference_name: Optional[str] = None,
-        labels: Optional[np.ndarray] = None,
     ) -> None:
         super().__init__()
         # Need to compare to None because they may be np arrays which cannot be

--- a/dataquality/loggers/model_logger/image_classification.py
+++ b/dataquality/loggers/model_logger/image_classification.py
@@ -24,7 +24,6 @@ class ImageClassificationModelLogger(TextClassificationModelLogger):
         split: str = "",
         epoch: Optional[int] = None,
         inference_name: Optional[str] = None,
-        labels: Optional[np.ndarray] = None,
     ) -> None:
         super().__init__(
             embs=embs,

--- a/dataquality/loggers/model_logger/semantic_segmentation.py
+++ b/dataquality/loggers/model_logger/semantic_segmentation.py
@@ -58,7 +58,6 @@ class SemanticSegmentationModelLogger(BaseGalileoModelLogger):
         split: str = "",
         epoch: Optional[int] = None,
         inference_name: Optional[str] = None,
-        labels: Optional[np.ndarray] = None,
     ) -> None:
         """Takes in SemSeg inputs as a list of batches
 

--- a/dataquality/loggers/model_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/model_logger/seq2seq/seq2seq_base.py
@@ -36,7 +36,6 @@ class Seq2SeqModelLogger(BaseGalileoModelLogger):
         split: str = "",
         epoch: Optional[int] = None,
         inference_name: Optional[str] = None,
-        labels: Optional[np.ndarray] = None,
     ) -> None:
         super().__init__(
             embs=embs,
@@ -46,11 +45,9 @@ class Seq2SeqModelLogger(BaseGalileoModelLogger):
             split=split,
             epoch=epoch,
             inference_name=inference_name,
-            labels=labels,
         )
         self.token_logprobs = pa.array([])
         self.top_logprobs = pa.array([])
-        self.labels = labels
 
     @property
     def token_map_key(self) -> str:

--- a/dataquality/loggers/model_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/model_logger/seq2seq/seq2seq_base.py
@@ -57,16 +57,12 @@ class Seq2SeqModelLogger(BaseGalileoModelLogger):
 
     def validate_and_format(self) -> None:
         """Validate the lengths, calculate token level dep, extract GT probs"""
-        if self.labels is not None:
-            self.labels = self._convert_tensor_ndarray(self.labels)
         self.logits = self._convert_tensor_ndarray(self.logits)
         self.ids = self._convert_tensor_ndarray(self.ids)
         assert len(self.ids) == len(self.logits), (
             "Must pass in a valid batch with equal id and logit length, got "
             f"id: {len(self.ids)},logits: {len(self.logits)}"
         )
-        if self.labels is not None:
-            assert len(self.labels) == len(self.ids), "TODO: Must be same len message"
 
         assert (
             self.logger_config.tokenizer is not None

--- a/dataquality/loggers/model_logger/text_classification.py
+++ b/dataquality/loggers/model_logger/text_classification.py
@@ -81,7 +81,6 @@ class TextClassificationModelLogger(BaseGalileoModelLogger):
         split: str = "",
         epoch: Optional[int] = None,
         inference_name: Optional[str] = None,
-        labels: Optional[np.ndarray] = None,
     ) -> None:
         super().__init__(
             embs=embs,

--- a/dataquality/loggers/model_logger/text_multi_label.py
+++ b/dataquality/loggers/model_logger/text_multi_label.py
@@ -69,7 +69,6 @@ class TextMultiLabelModelLogger(TextClassificationModelLogger):
         split: str = "",
         epoch: Optional[int] = None,
         inference_name: Optional[str] = None,
-        labels: Optional[np.ndarray] = None,
     ) -> None:
         super().__init__(
             embs=embs,

--- a/dataquality/loggers/model_logger/text_ner.py
+++ b/dataquality/loggers/model_logger/text_ner.py
@@ -102,7 +102,6 @@ class TextNERModelLogger(BaseGalileoModelLogger):
         split: str = "",
         epoch: Optional[int] = None,
         inference_name: Optional[str] = None,
-        labels: Optional[np.ndarray] = None,
     ) -> None:
         super().__init__(
             embs=embs,


### PR DESCRIPTION
In doing a refactor I noticed that labels are never used in model loggers, so let's remove them! 