### PR TITLE
chore: add support for Tokenizer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from transformers import (
     AutoModelForSequenceClassification,
     AutoTokenizer,
     T5ForConditionalGeneration,
+    T5Tokenizer,
 )
 from vaex.dataframe import DataFrame
 
@@ -60,6 +61,16 @@ try:
 except Exception:
     tokenizer_T5 = AutoTokenizer.from_pretrained(HF_TEST_T5_PATH, device="cpu")
     tokenizer_T5.save_pretrained(LOCAL_T5_PATH)
+
+try:
+    tokenizer_T5_not_auto = T5Tokenizer.from_pretrained(
+        LOCAL_T5_PATH, use_fast=True, device="cpu"
+    )
+except Exception:
+    tokenizer_T5_not_auto = T5Tokenizer.from_pretrained(
+        HF_TEST_T5_PATH, use_fast=True, device="cpu"
+    )
+    tokenizer_T5_not_auto.save_pretrained(LOCAL_T5_PATH)
 
 try:
     model_T5 = T5ForConditionalGeneration.from_pretrained(LOCAL_T5_PATH).to("cpu")

--- a/tests/integrations/seq2seq/test_hf.py
+++ b/tests/integrations/seq2seq/test_hf.py
@@ -1,0 +1,43 @@
+from typing import Callable
+
+from pytest import raises
+from tokenizers import Tokenizer
+from tokenizers.models import BPE
+from transformers import PreTrainedTokenizerFast
+
+from dataquality.integrations.seq2seq.hf import set_tokenizer
+from tests.conftest import TestSessionVariables, tokenizer_T5, tokenizer_T5_not_auto
+
+
+def test_set_tokenizer(
+    set_test_config: Callable,
+    cleanup_after_use: Callable,
+    test_session_vars: TestSessionVariables,
+) -> None:
+    """
+    Test that we can use either a PreTrainedFastTokenizer from HF or a Tokenizer from
+    tokenizers, but not another type of tokenizer.
+    """
+    set_test_config(task_type="seq2seq")
+
+    # Check that we can set the T5 auto tokenizer (of type PreTrainedTokenizerFast)
+    assert isinstance(tokenizer_T5, PreTrainedTokenizerFast)
+    set_tokenizer(tokenizer_T5)
+
+    # Check that we can set a generic tokenizer (of type Tokenizer)
+    tokenizer = Tokenizer(BPE(unk_token="[UNK]"))
+    assert isinstance(tokenizer, Tokenizer)
+    set_tokenizer(tokenizer)
+
+    # Check that the T5 tokenizer of another type is not working for now
+    tokenizer = tokenizer_T5_not_auto
+    assert not (
+        isinstance(tokenizer, PreTrainedTokenizerFast)
+        or isinstance(tokenizer, Tokenizer)
+    )
+    with raises(AssertionError) as context:
+        set_tokenizer(tokenizer_T5_not_auto)
+        assert (
+            str(context.value)
+            == "Tokenizer must be an instance of PreTrainedTokenizerFast"
+        )


### PR DESCRIPTION
Adding support for tokenizers of type Tokenizer (to support Cohere) https://app.shortcut.com/galileo/story/8963

The class `from tokenizers import Tokenizer` is a performant implementation of lots of popular tokenizers https://github.com/huggingface/tokenizers. It is implemented in Rust with bindings in Python.

The class `from transformers import PreTrainedTokenizerFast` seems more popular as it integrates easier with transformers and many trained tokenizers have this type https://huggingface.co/docs/transformers/v4.33.2/en/main_classes/tokenizer#transformers.PreTrainedTokenizerFast.

We first implemented support for PreTrainedTokenizerFast and require support for Tokenizer (in particular for Cohere). It turns out a Tokenizer can be converted into a PreTrainedTokenizerFast, so that's what we'll use for now since it allows minimal code change. We can think about a more general solution if we'll need to support more general tokenizers