### PR TITLE
Fix ultraytics validator

### DIFF
--- a/dataquality/integrations/ultralytics.py
+++ b/dataquality/integrations/ultralytics.py
@@ -413,7 +413,7 @@ class Callback:
         :param validator: the validator"""
         self.split = Split.validation
         self.validator = validator
-        model = validator.model or self.model
+        model = self.model
         if not self.hooked:
             self.register_hooks(model.model)
             self.bl = BatchLogger(validator.preprocess)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ doc = [
     "sphinx-markdown-builder"
 ]
 test = [
-    "ultralytics>=8.0.190",
+    "ultralytics>=8.0.209",
     "pytest>=7.2.1",
     "freezegun>=1.2.2",
     "coverage[toml]>=7.0.5",


### PR DESCRIPTION
Ultralytics v8.0.209 removed the `model` from the `validator`'s attributes