### PR TITLE
chore: model optional model type required

### DIFF
--- a/dataquality/integrations/seq2seq/core.py
+++ b/dataquality/integrations/seq2seq/core.py
@@ -16,10 +16,12 @@ from dataquality.utils.task_helpers import get_task_type
 @check_noop
 def set_tokenizer(
     tokenizer: Union[PreTrainedTokenizerFast, Tokenizer],
+    model_type: str,
     max_input_tokens: Optional[int] = None,
     max_target_tokens: Optional[int] = None,
 ) -> None:
     """Seq2seq only. Set the tokenizer for your run
+
     Must be either a Tokenizer or a fast pretrained tokenizer, and must support
     `decode`, `encode`, `encode_plus`.
     We will use this tokenizer for both the input and the target. They will both be
@@ -38,7 +40,7 @@ def set_tokenizer(
             tokenizer.model_max_length
 
     You can set your tokenizer via the `set_tokenizer(tok)` function imported from
-    `dataquality.integrations.seq2seq.hf`
+    `dataquality.integrations.seq2seq.core`
 
     NOTE: We assume that the tokenizer you provide is the same tokenizer used for
     training. This must be true in order to align inputs and outputs correctly. Ensure
@@ -50,6 +52,12 @@ def set_tokenizer(
         "This method is only supported for seq2seq tasks. "
         "Make sure to set the task type with dq.init()"
     )
+
+    if model_type not in Seq2SeqModelType.members():
+        raise ValueError(
+            f"model_type must be one of {Seq2SeqModelType.members()}, got {model_type}"
+        )
+    seq2seq_logger_config.model_type = Seq2SeqModelType(model_type)
 
     if isinstance(tokenizer, PreTrainedTokenizerFast):
         tokenizer_dq = tokenizer
@@ -77,7 +85,7 @@ def set_tokenizer(
         )
 
     # This is relevant only for Encoder Decoder Models
-    if seq2seq_logger_config.model_type == Seq2SeqModelType.encoder_decoder:
+    if model_type == Seq2SeqModelType.encoder_decoder:
         seq2seq_logger_config.max_target_tokens = max_target_tokens
         if seq2seq_logger_config.max_target_tokens is None:
             seq2seq_logger_config.max_target_tokens = tokenizer_dq.model_max_length
@@ -120,11 +128,13 @@ def watch(
     and generation config and not attaching any hooks to the model. We call it 'watch'
     for consistency.
     """
-    task_type = get_task_type()
-    assert task_type in TaskType.get_seq2seq_tasks(), (
-        "This method is only supported for seq2seq tasks. "
-        "Make sure to set the task type with dq.init()"
+    set_tokenizer(
+        tokenizer=tokenizer,
+        model_type=model_type,
+        max_input_tokens=max_input_tokens,
+        max_target_tokens=max_target_tokens,
     )
+
     if model:
         assert isinstance(
             model, PreTrainedModel
@@ -132,13 +142,6 @@ def watch(
         assert (
             model.can_generate()
         ), "model must contain a `generate` method for seq2seq"
-
-    if model_type not in Seq2SeqModelType.members():
-        raise ValueError(
-            f"model_type must be one of {Seq2SeqModelType.members()}, got {model_type}"
-        )
-
-    set_tokenizer(tokenizer, max_input_tokens, max_target_tokens)
 
     if model_type == Seq2SeqModelType.decoder_only and not response_template:
         raise GalileoException(
@@ -154,7 +157,6 @@ def watch(
     seq2seq_logger_config.response_template = response_template
     seq2seq_logger_config.model = model
     seq2seq_logger_config.generation_config = generation_config
-    seq2seq_logger_config.model_type = Seq2SeqModelType(model_type)
 
     generation_splits = generation_splits or []
     generation_splits_set = {Split.test}

--- a/dataquality/integrations/seq2seq/s2s_trainer.py
+++ b/dataquality/integrations/seq2seq/s2s_trainer.py
@@ -19,11 +19,12 @@ from transformers import (
 
 import dataquality as dq
 from dataquality.exceptions import GalileoException
-from dataquality.integrations.seq2seq.hf import watch
+from dataquality.integrations.seq2seq.core import watch
 from dataquality.integrations.seq2seq.schema import (
     Seq2SeqGenerationConfig,
     Seq2SeqTrainingConfig,
 )
+from dataquality.schemas.seq2seq import Seq2SeqModelType
 from dataquality.schemas.split import Split
 from dataquality.utils.torch import cleanup_cuda
 
@@ -153,14 +154,14 @@ def get_trainer(
     )
 
     watch(
-        model=model,
         tokenizer=tokenizer,
+        model_type=Seq2SeqModelType.encoder_decoder,
+        model=model,
         generation_config=hf_generation_config,
         generation_splits=generation_config.generation_splits,
         max_input_tokens=max_input_tokens,
         max_target_tokens=max_target_tokens,
     )
-
     return model, dataloaders
 
 

--- a/dataquality/loggers/data_logger/seq2seq/formatters.py
+++ b/dataquality/loggers/data_logger/seq2seq/formatters.py
@@ -7,7 +7,7 @@ from vaex import DataFrame
 from dataquality.loggers.data_logger.seq2seq.seq2seq_base import Seq2SeqDataLogger
 from dataquality.loggers.logger_config.seq2seq.seq2seq_base import Seq2SeqLoggerConfig
 from dataquality.schemas.seq2seq import Seq2SeqInputCols as S2SIC
-from dataquality.schemas.seq2seq import Seq2SeqModelTypes
+from dataquality.schemas.seq2seq import Seq2SeqModelType
 from dataquality.utils.seq2seq.decoder_only import extract_tokenized_responses
 from dataquality.utils.seq2seq.offsets import (
     add_input_cutoff_to_df,
@@ -285,14 +285,14 @@ class DecoderOnlyDataFormatter(BaseSeq2SeqDataFormatter):
         return df
 
 
-FORMATTER_MAP: Dict[Seq2SeqModelTypes, Type[BaseSeq2SeqDataFormatter]] = {
-    Seq2SeqModelTypes.encoder_decoder: EncoderDecoderDataFormatter,
-    Seq2SeqModelTypes.decoder_only: DecoderOnlyDataFormatter,
+FORMATTER_MAP: Dict[Seq2SeqModelType, Type[BaseSeq2SeqDataFormatter]] = {
+    Seq2SeqModelType.encoder_decoder: EncoderDecoderDataFormatter,
+    Seq2SeqModelType.decoder_only: DecoderOnlyDataFormatter,
 }
 
 
 def get_data_formatter(
-    model_type: Seq2SeqModelTypes, logger_config: Seq2SeqLoggerConfig
+    model_type: Seq2SeqModelType, logger_config: Seq2SeqLoggerConfig
 ) -> BaseSeq2SeqDataFormatter:
     """Returns the data formatter for the given model_type"""
     return FORMATTER_MAP[model_type](logger_config)

--- a/dataquality/loggers/data_logger/seq2seq/formatters.py
+++ b/dataquality/loggers/data_logger/seq2seq/formatters.py
@@ -46,7 +46,7 @@ class EncoderDecoderDataFormatter(BaseSeq2SeqDataFormatter):
         This class must implement the `encode`, `decode`, and `encode_plus` methods
 
         You can set your tokenizer via either the seq2seq `set_tokenizer()` or
-        `watch(..., tokenizer, ...)` functions in `dataquality.integrations.seq2seq.hf`
+        `watch(tokenizer, ...)` functions in `dataquality.integrations.seq2seq.core`
     2. A two column (i.e. completion) dataset (pandas/huggingface etc) with string
         'text' (model <Input> / <Instruction> / <Prompt>, ...) and 'label' (model
         <Target> / (<Completion> / ...) columns + a data sample id column.
@@ -63,7 +63,7 @@ class EncoderDecoderDataFormatter(BaseSeq2SeqDataFormatter):
         `dq.log_dataset(ds, text="text", label="summary", id="id")`
 
     Putting it all together:
-        from dataquality.integrations.seq2seq.hf import set_tokenizer
+        from dataquality.integrations.seq2seq.core import set_tokenizer
         from datasets import load_dataset
         from transformers import T5TokenizerFast
 
@@ -75,6 +75,7 @@ class EncoderDecoderDataFormatter(BaseSeq2SeqDataFormatter):
         # You can either use `set_tokenizer()` or `watch()`
         set_tokenizer(
             tokenizer,
+            "encoder_decoder",
             max_input_tokens=512,
             max_target_tokens=128
         )
@@ -159,7 +160,7 @@ class DecoderOnlyDataFormatter(BaseSeq2SeqDataFormatter):
         This class must implement the `encode`, `decode`, and `encode_plus` methods
 
         You can set your tokenizer via either the seq2seq `set_tokenizer()` or
-        `watch(..., tokenizer, ...)` functions in `dataquality.integrations.seq2seq.hf`
+        `watch(tokenizer, ...)` functions in `dataquality.integrations.seq2seq.core`
     2. A two column (i.e. completion) dataset (pandas/huggingface etc) with string
         'text' (model <Input> / <Instruction> / <Prompt>, ...) and 'label' (model
         <Target> / (<Completion> / ...) columns + a data sample id column.
@@ -176,7 +177,7 @@ class DecoderOnlyDataFormatter(BaseSeq2SeqDataFormatter):
         `dq.log_dataset(ds, text="text", label="summary", id="id")`
 
     Putting it all together:
-        from dataquality.integrations.seq2seq.hf import set_tokenizer
+        from dataquality.integrations.seq2seq.core import set_tokenizer
         from datasets import load_dataset
         from transformers import T5TokenizerFast
 
@@ -188,6 +189,7 @@ class DecoderOnlyDataFormatter(BaseSeq2SeqDataFormatter):
         # You can either use `set_tokenizer()` or `watch()`
         set_tokenizer(
             tokenizer,
+            "encoder_decoder",
             max_input_tokens=512,
             max_target_tokens=128
         )

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -114,13 +114,13 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         )
         assert self.logger_config.tokenizer, (
             "You must set your tokenizer before logging. "
-            "Use `dq.integrations.seq2seq.hf.set_tokenizer`"
+            "Use `dq.integrations.seq2seq.core.set_tokenizer`"
         )
         model_type = self.logger_config.model_type
         if model_type is None:
             raise GalileoException(
                 "You must set your model type before logging. Use "
-                "`dataquality.integrations.seq2seq.hf.watch`"
+                "`dataquality.integrations.seq2seq.core.watch`"
             )
 
         # Now that model_type has been set with `watch` we set formatter
@@ -280,18 +280,18 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         if model is None:
             raise GalileoException(
                 "You must set your model before logging. Use "
-                "`dataquality.integrations.seq2seq.hf.watch`"
+                "`dataquality.integrations.seq2seq.core.watch`"
             )
         if tokenizer is None:
             raise GalileoException(
                 "You must set your tokenizer before logging. Use "
-                "`dataquality.integrations.seq2seq.hf.watch`"
+                "`dataquality.integrations.seq2seq.core.watch`"
             )
         assert isinstance(max_input_tokens, int)
         if generation_config is None:
             raise GalileoException(
                 "You must set your generation config before logging. Use "
-                "`dataquality.integrations.seq2seq.hf.watch`"
+                "`dataquality.integrations.seq2seq.core.watch`"
             )
         if split not in logger_config.generation_splits:
             print("Skipping generation for split", split)
@@ -362,7 +362,7 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         if tokenizer is None:
             raise GalileoException(
                 "You must set your tokenizer before calling dq.finish. Use "
-                "`dataquality.integrations.seq2seq.hf.watch`"
+                "`dataquality.integrations.seq2seq.core.watch`"
             )
 
         # Use the computed offsets from `validate_and_format`

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -18,7 +18,7 @@ from dataquality.loggers.logger_config.seq2seq.seq2seq_base import (
 )
 from dataquality.schemas.dataframe import BaseLoggerDataFrames
 from dataquality.schemas.seq2seq import Seq2SeqInputCols as S2SIC
-from dataquality.schemas.seq2seq import Seq2SeqModelTypes
+from dataquality.schemas.seq2seq import Seq2SeqModelType
 from dataquality.schemas.split import Split
 from dataquality.utils.emb import convert_pa_to_np
 from dataquality.utils.seq2seq.generation import (
@@ -84,6 +84,9 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
 
         # Formatter distinguishes behavior between EncoderDecoder and DecoderOnly
         model_type = self.logger_config.model_type
+        assert (
+            model_type is not None
+        ), "model_type must be set in `watch` before logging"
         if model_type == "decoder_only":
             # Only requied for Decoder-Only models
             self.formatted_prompts: List[str] = []
@@ -124,7 +127,7 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
             "Use `dq.integrations.seq2seq.hf.set_tokenizer`"
         )
 
-        if self.logger_config.model_type == Seq2SeqModelTypes.decoder_only:
+        if self.logger_config.model_type == Seq2SeqModelType.decoder_only:
             texts = self.formatted_prompts
             max_tokens = self.logger_config.max_input_tokens
         else:

--- a/dataquality/loggers/logger_config/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/logger_config/seq2seq/seq2seq_base.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Set
 from transformers import GenerationConfig, PreTrainedModel, PreTrainedTokenizerFast
 
 from dataquality.loggers.logger_config.base_logger_config import BaseLoggerConfig
-from dataquality.schemas.seq2seq import Seq2SeqModelTypes
+from dataquality.schemas.seq2seq import Seq2SeqModelType
 from dataquality.schemas.split import Split
 
 
@@ -18,7 +18,7 @@ class Seq2SeqLoggerConfig(BaseLoggerConfig):
     model: Optional[PreTrainedModel] = None
     generation_config: Optional[GenerationConfig] = None
     generation_splits: Set[Split] = set()
-    model_type: Seq2SeqModelTypes = Seq2SeqModelTypes.encoder_decoder
+    model_type: Optional[Seq2SeqModelType] = None
     # Decoder only below
     id_to_formatted_prompt_length: Dict[str, Dict[int, int]] = defaultdict(dict)
     response_template: Optional[List[int]] = None

--- a/dataquality/loggers/model_logger/seq2seq/formatters.py
+++ b/dataquality/loggers/model_logger/seq2seq/formatters.py
@@ -6,7 +6,7 @@ from scipy.special import log_softmax
 
 from dataquality.loggers.base_logger import BaseGalileoLogger
 from dataquality.loggers.logger_config.seq2seq.seq2seq_base import Seq2SeqLoggerConfig
-from dataquality.schemas.seq2seq import Seq2SeqModelTypes
+from dataquality.schemas.seq2seq import Seq2SeqModelType
 from dataquality.utils.seq2seq import remove_padding
 from dataquality.utils.seq2seq.logprobs import (
     get_top_logprob_indices,
@@ -175,14 +175,14 @@ class DecoderOnlyModelFormatter(BaseSeq2SeqModelFormatter):
         return response_labels, sample_logprobs, sample_top_indices
 
 
-FORMATTER_MAP: Dict[Seq2SeqModelTypes, Type[BaseSeq2SeqModelFormatter]] = {
-    Seq2SeqModelTypes.encoder_decoder: EncoderDecoderModelFormatter,
-    Seq2SeqModelTypes.decoder_only: DecoderOnlyModelFormatter,
+FORMATTER_MAP: Dict[Seq2SeqModelType, Type[BaseSeq2SeqModelFormatter]] = {
+    Seq2SeqModelType.encoder_decoder: EncoderDecoderModelFormatter,
+    Seq2SeqModelType.decoder_only: DecoderOnlyModelFormatter,
 }
 
 
 def get_model_formatter(
-    model_type: Seq2SeqModelTypes, logger_config: Seq2SeqLoggerConfig
+    model_type: Seq2SeqModelType, logger_config: Seq2SeqLoggerConfig
 ) -> BaseSeq2SeqModelFormatter:
     """Returns the model formatter for the given model_type"""
     return FORMATTER_MAP[model_type](logger_config)

--- a/dataquality/loggers/model_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/model_logger/seq2seq/seq2seq_base.py
@@ -63,6 +63,9 @@ class Seq2SeqModelLogger(BaseGalileoModelLogger):
         self.top_logprobs = pa.array([])
         # Formatter distinguishes behavior between EncoderDecoder and DecoderOnly
         model_type = self.logger_config.model_type
+        assert (
+            model_type is not None
+        ), "model_type must be set in `watch` before logging"
         self.formatter = get_model_formatter(model_type, self.logger_config)
 
     @property

--- a/dataquality/loggers/model_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/model_logger/seq2seq/seq2seq_base.py
@@ -94,7 +94,7 @@ class Seq2SeqModelLogger(BaseGalileoModelLogger):
         if model_type is None:
             raise GalileoException(
                 "You must set your model type before logging. Use "
-                "`dataquality.integrations.seq2seq.hf.watch`"
+                "`dataquality.integrations.seq2seq.core.watch`"
             )
 
         # Now that model_type has been set with `watch` we set formatter

--- a/dataquality/loggers/model_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/model_logger/seq2seq/seq2seq_base.py
@@ -3,12 +3,16 @@ from typing import Dict, List, Optional, Tuple, Union
 import numpy as np
 import pyarrow as pa
 
+from dataquality.exceptions import GalileoException
 from dataquality.loggers.logger_config.seq2seq.seq2seq_base import (
     Seq2SeqLoggerConfig,
     seq2seq_logger_config,
 )
 from dataquality.loggers.model_logger.base_model_logger import BaseGalileoModelLogger
-from dataquality.loggers.model_logger.seq2seq.formatters import get_model_formatter
+from dataquality.loggers.model_logger.seq2seq.formatters import (
+    BaseSeq2SeqModelFormatter,
+    get_model_formatter,
+)
 from dataquality.schemas.seq2seq import TOP_LOGPROBS_SCHEMA
 from dataquality.schemas.seq2seq import Seq2SeqOutputCols as C
 from dataquality.schemas.split import Split
@@ -62,11 +66,7 @@ class Seq2SeqModelLogger(BaseGalileoModelLogger):
         self.token_logprobs = pa.array([])
         self.top_logprobs = pa.array([])
         # Formatter distinguishes behavior between EncoderDecoder and DecoderOnly
-        model_type = self.logger_config.model_type
-        assert (
-            model_type is not None
-        ), "model_type must be set in `watch` before logging"
-        self.formatter = get_model_formatter(model_type, self.logger_config)
+        self.formatter: Optional[BaseSeq2SeqModelFormatter] = None
 
     @property
     def split_key(self) -> str:
@@ -85,9 +85,21 @@ class Seq2SeqModelLogger(BaseGalileoModelLogger):
             f"id: {len(self.ids)},logits: {len(self.logits)}"
         )
 
-        assert (
-            self.logger_config.tokenizer is not None
-        ), "Must set your tokenizer. Use `dq.integrations.seq2seq.hf.set_tokenizer`"
+        assert self.logger_config.tokenizer is not None, (
+            "Must set your tokenizer. Use `dq.integrations.seq2seq.core.watch` or "
+            "`dq.integrations.seq2seq.core.watch`"
+        )
+
+        model_type = self.logger_config.model_type
+        if model_type is None:
+            raise GalileoException(
+                "You must set your model type before logging. Use "
+                "`dataquality.integrations.seq2seq.hf.watch`"
+            )
+
+        # Now that model_type has been set with `watch` we set formatter
+        self.formatter = get_model_formatter(model_type, self.logger_config)
+
         (
             self.token_logprobs,
             self.top_logprobs,
@@ -127,7 +139,10 @@ class Seq2SeqModelLogger(BaseGalileoModelLogger):
                 len(batch_top_logprobs) == batch_size
                 len(batch_top_logprobs[i]) = num_tokens_in_label[i]
         """
-        assert self.logger_config.tokenizer is not None  # Needed for linting
+        # Formatter and tokenizer will have already been set in `validate_and_format`
+        # These are needed for linting
+        assert self.logger_config.tokenizer is not None
+        assert self.formatter is not None
 
         batch_token_logprobs = []
         batch_top_logprobs = []

--- a/dataquality/schemas/seq2seq.py
+++ b/dataquality/schemas/seq2seq.py
@@ -14,9 +14,13 @@ TOP_K = 5
 GENERATION_BATCH_SIZE = 100
 
 
-class Seq2SeqModelTypes(str, Enum):
+class Seq2SeqModelType(str, Enum):
     encoder_decoder = "encoder_decoder"
     decoder_only = "decoder_only"
+
+    @staticmethod
+    def members() -> List[str]:
+        return list(map(lambda i: i.value, list(Seq2SeqModelType)))
 
 
 class Seq2SeqInputCols(str, Enum):

--- a/docs/notebooks/Seq2Seq_Decoder_Only_Dq_Fake_Data.ipynb
+++ b/docs/notebooks/Seq2Seq_Decoder_Only_Dq_Fake_Data.ipynb
@@ -207,7 +207,7 @@
     "os.environ[\"GALILEO_PASSWORD\"]=\"\"\n",
     "\n",
     "import dataquality as dq\n",
-    "from dataquality.integrations.seq2seq.hf import watch\n",
+    "from dataquality.integrations.seq2seq.core import watch\n",
     "dq.configure()"
    ]
   },

--- a/docs/notebooks/Seq2Seq_Dq_Fake_Data.ipynb
+++ b/docs/notebooks/Seq2Seq_Dq_Fake_Data.ipynb
@@ -7,10 +7,10 @@
    "source": [
     "# Seq2Seq DQ Test Notebook\n",
     "\n",
-    "In this notebook we test the dq client for **EncoderDecoder** models using simulated / fake data. The main intention is to battle test the different components of the client without training an actual model - i.e. optimizing for speed!\n",
+    "In this notebook we test the dq client for Seq2Seq using simulated / fake data. The main intention is to battle test the different components of the client without training an actual model - i.e. optimizing for speed!\n",
     "\n",
     "Things that we want to test:\n",
-    "1. Using the watch function - to set the tokenizer + generation_config\n",
+    "1. Setting the tokenizer\n",
     "2. Logging data (input + target outputs)\n",
     "3. Logging model outputs 1+ epoch\n",
     "4. Fake model generations - interestingly the best way to do this may be with a small validation dataset + a real LLM model. This depends a bit on design decisions around logging for generation.\n",
@@ -27,8 +27,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# from transformers import T5Tokenizer, T5ForConditionalGeneration\n",
     "from datasets import load_dataset, Dataset\n",
     "import numpy as np\n",
+    "# import torch\n",
     "\n",
     "%load_ext autoreload\n",
     "%autoreload 2"
@@ -137,17 +139,8 @@
     "\n",
     "import dataquality as dq\n",
     "from dataquality.integrations.seq2seq.core import watch\n",
-    "dq.configure()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3fe8a83a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dq.init(\"seq2seq\", project_name=\"Seq2Seq-test\", run_name=\"with-model-embs2\")\n",
+    "dq.configure()\n",
+    "dq.init(\"seq2seq\")\n",
     "\n",
     "temperature = 0.4\n",
     "generation_config = GenerationConfig(\n",
@@ -159,12 +152,9 @@
     "\n",
     "watch(\n",
     "    tokenizer,\n",
-    "    \"encoder_decoder\",\n",
-    "    model,\n",
-    "    generation_config,\n",
-    "    generation_splits=[],\n",
-    "    max_input_tokens=512,\n",
-    "    max_target_tokens=512\n",
+    "    model_type=\"encoder_decoder\"\n",
+    "    model=model,\n",
+    "    generation_config=generation_config,\n",
     ")"
    ]
   },
@@ -215,9 +205,7 @@
     "        batch_ids = ids[i: i + batch_size]\n",
     "        # Shape - [bs, max_seq_len, num_logits]\n",
     "        fake_logits = np.ones((batch_size, max_seq_length, num_logits))\n",
-    "        fake_embs = np.random.random((batch_size, 768))\n",
     "        dq.log_model_outputs(\n",
-    "            embs = fake_embs,\n",
     "            logits = fake_logits,\n",
     "            ids = batch_ids\n",
     "        )\n",
@@ -231,9 +219,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a8e363f0",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dq.finish()"
@@ -250,9 +236,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "mlcore",
    "language": "python",
-   "name": "python3"
+   "name": "mlcore"
   },
   "language_info": {
    "codemirror_mode": {
@@ -264,7 +250,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/Tabular-Data.ipynb
+++ b/docs/notebooks/Tabular-Data.ipynb
@@ -20,29 +20,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "ba6c8e04-590b-45ac-b537-e0fc3345287f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/elliottchartock/Code/dataquality/dataquality/core/__init__.py:27: GalileoWarning: configure is deprecated, use dq.set_console_url and dq.login\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "📡 https://console.dev.rungalileo.io\n",
-      "🔭 Logging you into Galileo\n",
-      "\n",
-      "🚀 You're logged in to Galileo as galileo@rungalileo.io!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "\n",
@@ -57,75 +38,10 @@
     "import dataquality as dq\n",
     "dq.configure()\n",
     "\n",
-    "# # run_name = \"fine-wine\"\n",
-    "# run_name = \"iris-uris-weallris\"\n",
+    "# run_name = \"fine-wine\"\n",
+    "run_name = \"iris-uris-weallris\"\n",
     "\n",
-    "# dq.init(\"tabular_classification\", \"tabular-project\", run_name)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "9b4704db",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "All alerts removed for run auto_s2s/full_alpaca\n",
-      "Job inference successfully resubmitted. New results will be available soon at https://console.dev.rungalileo.io/insights/a29cfac8-773d-45f2-aaac-adfd61fe6ef5/b2eb5e97-eade-41d9-8caf-9e680568e77b?split=training&taskType=8\n",
-      "Waiting for job (you can safely close this window)...\n",
-      "\tProcessed data embs found\n",
-      "\tMeasuring data embeddings sample similarity for training\n",
-      "\tFinding semantic clusters for training\n",
-      "\tSaving processed training data\n",
-      "\tUploading processed training data\n",
-      "\t[training] 👀 Looking for data anomalies\n",
-      "\tFinding semantic clusters for validation\n",
-      "\tSaving processed validation data\n",
-      "\tUploading processed validation data\n",
-      "\tFinding semantic clusters for test\n",
-      "\tSaving processed test data\n",
-      "Done! Job finished with status completed\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'project_id': 'a29cfac8-773d-45f2-aaac-adfd61fe6ef5',\n",
-       " 'run_id': 'b2eb5e97-eade-41d9-8caf-9e680568e77b',\n",
-       " 'job_id': '49deec51-881a-4baa-a7e9-4ec213666f8f',\n",
-       " 'job_name': 'inference',\n",
-       " 'task_type': 8,\n",
-       " 'labels': [],\n",
-       " 'ner_labels': [],\n",
-       " 'tasks': None,\n",
-       " 'non_inference_logged': True,\n",
-       " 'migration_name': None,\n",
-       " 'xray': True,\n",
-       " 'process_existing_inference_runs': True,\n",
-       " 'feature_names': None,\n",
-       " 'prompt_dataset_id': None,\n",
-       " 'prompt_template_version_id': None,\n",
-       " 'monitor_batch_id': None,\n",
-       " 'prompt_settings': None,\n",
-       " 'prompt_scorers_configuration': None,\n",
-       " 'prompt_registered_scorers_configuration': None,\n",
-       " 'prompt_scorer_settings': None,\n",
-       " 'message': 'Processing job!',\n",
-       " 'link': 'https://console.dev.rungalileo.io/insights/a29cfac8-773d-45f2-aaac-adfd61fe6ef5/b2eb5e97-eade-41d9-8caf-9e680568e77b?split=training&taskType=8'}"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from dataquality.internal import reprocess_run\n",
-    "\n",
-    "reprocess_run(project_name=\"Seq2Seq-test\", run_name=\"with-model-embs\")"
+    "dq.init(\"tabular_classification\", \"tabular-project\", run_name)"
    ]
   },
   {

--- a/docs/notebooks/Tabular-Data.ipynb
+++ b/docs/notebooks/Tabular-Data.ipynb
@@ -20,10 +20,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "ba6c8e04-590b-45ac-b537-e0fc3345287f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/elliottchartock/Code/dataquality/dataquality/core/__init__.py:27: GalileoWarning: configure is deprecated, use dq.set_console_url and dq.login\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "📡 https://console.dev.rungalileo.io\n",
+      "🔭 Logging you into Galileo\n",
+      "\n",
+      "🚀 You're logged in to Galileo as galileo@rungalileo.io!\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "\n",
@@ -38,10 +57,75 @@
     "import dataquality as dq\n",
     "dq.configure()\n",
     "\n",
-    "# run_name = \"fine-wine\"\n",
-    "run_name = \"iris-uris-weallris\"\n",
+    "# # run_name = \"fine-wine\"\n",
+    "# run_name = \"iris-uris-weallris\"\n",
     "\n",
-    "dq.init(\"tabular_classification\", \"tabular-project\", run_name)"
+    "# dq.init(\"tabular_classification\", \"tabular-project\", run_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "9b4704db",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All alerts removed for run auto_s2s/full_alpaca\n",
+      "Job inference successfully resubmitted. New results will be available soon at https://console.dev.rungalileo.io/insights/a29cfac8-773d-45f2-aaac-adfd61fe6ef5/b2eb5e97-eade-41d9-8caf-9e680568e77b?split=training&taskType=8\n",
+      "Waiting for job (you can safely close this window)...\n",
+      "\tProcessed data embs found\n",
+      "\tMeasuring data embeddings sample similarity for training\n",
+      "\tFinding semantic clusters for training\n",
+      "\tSaving processed training data\n",
+      "\tUploading processed training data\n",
+      "\t[training] 👀 Looking for data anomalies\n",
+      "\tFinding semantic clusters for validation\n",
+      "\tSaving processed validation data\n",
+      "\tUploading processed validation data\n",
+      "\tFinding semantic clusters for test\n",
+      "\tSaving processed test data\n",
+      "Done! Job finished with status completed\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'project_id': 'a29cfac8-773d-45f2-aaac-adfd61fe6ef5',\n",
+       " 'run_id': 'b2eb5e97-eade-41d9-8caf-9e680568e77b',\n",
+       " 'job_id': '49deec51-881a-4baa-a7e9-4ec213666f8f',\n",
+       " 'job_name': 'inference',\n",
+       " 'task_type': 8,\n",
+       " 'labels': [],\n",
+       " 'ner_labels': [],\n",
+       " 'tasks': None,\n",
+       " 'non_inference_logged': True,\n",
+       " 'migration_name': None,\n",
+       " 'xray': True,\n",
+       " 'process_existing_inference_runs': True,\n",
+       " 'feature_names': None,\n",
+       " 'prompt_dataset_id': None,\n",
+       " 'prompt_template_version_id': None,\n",
+       " 'monitor_batch_id': None,\n",
+       " 'prompt_settings': None,\n",
+       " 'prompt_scorers_configuration': None,\n",
+       " 'prompt_registered_scorers_configuration': None,\n",
+       " 'prompt_scorer_settings': None,\n",
+       " 'message': 'Processing job!',\n",
+       " 'link': 'https://console.dev.rungalileo.io/insights/a29cfac8-773d-45f2-aaac-adfd61fe6ef5/b2eb5e97-eade-41d9-8caf-9e680568e77b?split=training&taskType=8'}"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from dataquality.internal import reprocess_run\n",
+    "\n",
+    "reprocess_run(project_name=\"Seq2Seq-test\", run_name=\"with-model-embs\")"
    ]
   },
   {

--- a/tests/integrations/seq2seq/test_core.py
+++ b/tests/integrations/seq2seq/test_core.py
@@ -20,7 +20,7 @@ def test_set_tokenizer_PreTrainedFastTokenizer(
 
     # Check that we can set the T5 auto tokenizer (of type PreTrainedTokenizerFast)
     assert isinstance(tokenizer_T5, PreTrainedTokenizerFast)
-    set_tokenizer(tokenizer_T5)
+    set_tokenizer(tokenizer_T5, "encoder_decoder")
 
 
 def test_set_tokenizer_Tokenizer(
@@ -34,7 +34,7 @@ def test_set_tokenizer_Tokenizer(
     # Check that we can set a generic tokenizer (of type Tokenizer)
     tokenizer = Tokenizer(BPE(unk_token="[UNK]"))
     assert isinstance(tokenizer, Tokenizer)
-    set_tokenizer(tokenizer)
+    set_tokenizer(tokenizer, "encoder_decoder")
 
 
 def test_set_tokenizer_other(
@@ -55,7 +55,7 @@ def test_set_tokenizer_other(
         or isinstance(tokenizer, Tokenizer)
     )
     with pytest.raises(ValueError) as e:
-        set_tokenizer(tokenizer_T5_not_auto)
+        set_tokenizer(tokenizer_T5_not_auto, "encoder_decoder")
         assert str(e.value) == (
             "The tokenizer must be an instance of PreTrainedTokenizerFast "
             "or Tokenizer"
@@ -86,9 +86,6 @@ def test_watch_invalid_model_type(
     set_test_config(task_type="seq2seq")
     with pytest.raises(ValueError) as e:
         watch(tokenizer_T5, "invalid_model_type")
-        import pdb
-
-        pdb.set_trace()
         assert str(e.value) == (
             f"model_type must be one of {Seq2SeqModelType.members()}, "
             "got invalid_model_type"

--- a/tests/integrations/seq2seq/test_hf.py
+++ b/tests/integrations/seq2seq/test_hf.py
@@ -5,7 +5,7 @@ from tokenizers import Tokenizer
 from tokenizers.models import BPE
 from transformers import PreTrainedTokenizerFast
 
-from dataquality.integrations.seq2seq.hf import set_tokenizer
+from dataquality.integrations.seq2seq.core import set_tokenizer
 from tests.conftest import TestSessionVariables, tokenizer_T5, tokenizer_T5_not_auto
 
 

--- a/tests/loggers/test_seq2seq.py
+++ b/tests/loggers/test_seq2seq.py
@@ -11,7 +11,7 @@ from datasets import Dataset
 from transformers import GenerationConfig, T5ForConditionalGeneration
 
 import dataquality as dq
-from dataquality.integrations.seq2seq.hf import set_tokenizer, watch
+from dataquality.integrations.seq2seq.core import set_tokenizer, watch
 from dataquality.loggers.data_logger.base_data_logger import DataSet
 from dataquality.loggers.data_logger.seq2seq.seq2seq_base import Seq2SeqDataLogger
 from dataquality.loggers.logger_config.seq2seq.seq2seq_base import seq2seq_logger_config
@@ -63,7 +63,6 @@ def test_log_dataset_encoder_decoder(
     cleanup_after_use: Callable,
     test_session_vars: TestSessionVariables,
 ) -> None:
-    # TODO Test with watch
     set_test_config(task_type="seq2seq")
     logger = Seq2SeqDataLogger()
 
@@ -427,7 +426,13 @@ def test_tokenize_target_provide_maxlength_encoder_decoder(
     """
     set_test_config(task_type=TaskType.seq2seq)
     mock_generation_config = Mock(spec=GenerationConfig)
-    watch(model_T5, tokenizer_T5, mock_generation_config, max_target_tokens=7)
+    watch(
+        tokenizer_T5,
+        "encoder_decoder",
+        model_T5,
+        mock_generation_config,
+        max_target_tokens=7,
+    )
     ds = Dataset.from_dict(
         {
             "id": [0, 1],
@@ -460,7 +465,7 @@ def test_tokenize_target_doesnt_provide_maxlength_encoder_decoder(
     mock_generation_config = Mock(spec=GenerationConfig)
     # TODO Does using a real model here take a lot of time?
     #   should we just mock the model and add a max length?
-    watch(model_T5, tokenizer_T5, mock_generation_config)
+    watch(tokenizer_T5, "encoder_decoder", model_T5, mock_generation_config)
     ds = Dataset.from_dict(
         {
             "id": [0, 1],
@@ -495,8 +500,9 @@ def test_calculate_cutoffs_encoder_decoder(
     mock_model.device = "cpu"
     mock_generation_config = Mock(spec=GenerationConfig)
     watch(
-        mock_model,
         tokenizer_T5,
+        "encoder_decoder",
+        mock_model,
         mock_generation_config,
         max_input_tokens=3,
         max_target_tokens=5,

--- a/tests/utils/test_seq2seq_offset.py
+++ b/tests/utils/test_seq2seq_offset.py
@@ -7,7 +7,7 @@ from datasets import Dataset
 from transformers import GenerationConfig, T5ForConditionalGeneration
 
 import dataquality as dq
-from dataquality.integrations.seq2seq.hf import watch
+from dataquality.integrations.seq2seq.core import watch
 from dataquality.loggers.data_logger.seq2seq.seq2seq_base import Seq2SeqDataLogger
 from dataquality.schemas.seq2seq import Seq2SeqInputCols as C
 from dataquality.schemas.task_type import TaskType
@@ -155,7 +155,13 @@ def test_add_input_cutoff_to_df(
     mock_model = Mock(spec=T5ForConditionalGeneration)
     mock_model.device = "cpu"
     mock_generation_config = Mock(spec=GenerationConfig)
-    watch(mock_model, tokenizer_T5, mock_generation_config, max_input_tokens=4)
+    watch(
+        tokenizer_T5,
+        "encoder_decoder",
+        mock_model,
+        mock_generation_config,
+        max_input_tokens=4,
+    )
 
     input_1, input_2 = "dog dog dog done - tricked you", "bird"
     ds = Dataset.from_dict(
@@ -197,7 +203,13 @@ def test_add_target_cutoff_to_df(
     mock_model = Mock(spec=T5ForConditionalGeneration)
     mock_model.device = "cpu"
     mock_generation_config = Mock(spec=GenerationConfig)
-    watch(mock_model, tokenizer_T5, mock_generation_config, max_target_tokens=6)
+    watch(
+        tokenizer_T5,
+        "encoder_decoder",
+        mock_model,
+        mock_generation_config,
+        max_target_tokens=6,
+    )
 
     target_1, target_2 = "cat cat cat cat cat done", "cat"
     ds = Dataset.from_dict(

--- a/tests/utils/test_seq2seq_utils.py
+++ b/tests/utils/test_seq2seq_utils.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 from dataquality.exceptions import GalileoException
+from dataquality.loggers.model_logger.seq2seq.formatters import get_model_formatter
 from dataquality.loggers.model_logger.seq2seq.seq2seq_base import Seq2SeqModelLogger
 from dataquality.schemas.seq2seq import (
     TOP_K,
@@ -258,6 +259,7 @@ def test_model_logger_remove_padding() -> None:
     config = mock.MagicMock()
     config.id_to_tokens = {}
     config.id_to_tokens["training"] = dict(zip(list(range(4)), tokenized_labels))
+    config.model_type = "encoder_decoder"
     mock_tokenizer = mock.MagicMock()
     # First test removing from right padding
     config.tokenizer = mock_tokenizer
@@ -281,8 +283,7 @@ def test_model_logger_remove_padding() -> None:
         epoch=0,
     )
     logger = Seq2SeqModelLogger(**log_data)
-    logger.logger_config = config
-    logger.formatter.logger_config = config
+    logger.formatter = get_model_formatter("encoder_decoder", config)
     for sample_id, (sample_logprobs, sample_top_indices) in enumerate(
         zip(logprobs, top_indices)
     ):


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/9036/dq-make-the-model-a-manual-param-for-watch-fn?vc_group_by=day&ct_workflow=all&cf_workflow=500000005


In this PR we:
- Rename `Seq2SeqModelTypes` -> `Seq2SeqModelType`
- Make `model` optional in watch
- Make `model_type` required in watch
- Move watch fn to `core` 