### PR TITLE
fix: set formatter in seq2seq data logger

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 import sys
 from typing import Any, List, Optional


### PR DESCRIPTION
Ensure formatter is set. Updated pytests.

Tested e2e as well and verified it worked https://console.enterprise.rungalileo.io/insights/4c6a2573-bcf9-4b4e-8f39-a270a387b5c6/fa74f493-b2ae-44da-9ea2-f50620e1c24b?dataframeColumns=User_skip_use_as_completion%3B%26User_toxicity%3B%26chat_id%3B%26data_error_potential%3B%26input%3B%26perplexity%3B%26raw_data_hash%3B%26target%3B%26turn_id&groupedBy=chat_id&tab=em&insightsTab=clusters&taskType=8 

(credentials in 1pass) 