### PR TITLE
fix: remove test from generation splits

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/integrations/seq2seq/core.py
+++ b/dataquality/integrations/seq2seq/core.py
@@ -159,7 +159,7 @@ def watch(
     seq2seq_logger_config.generation_config = generation_config
 
     generation_splits = generation_splits or []
-    generation_splits_set = {Split.test}
+    generation_splits_set = set()
     for split in generation_splits:
         if split not in Split.get_valid_keys():
             warn(


### PR DESCRIPTION
***Description***

Final testing showed that no model logging still required the test split generation even when `generation_splits` was empty
```
[/usr/local/lib/python3.10/dist-packages/dataquality/utils/seq2seq/generation.py](https://localhost:8080/#) in add_generated_output_to_df(df, model, tokenizer, max_input_tokens, generation_config)
    213         Updated Dataframe with the generated columns added (see above)
    214     """
--> 215     model.eval()
    216     generated_data = BatchGenerationData()
    217
AttributeError: 'NoneType' object has no attribute 'eval'
```