### PR TITLE
feat: s2s add high dep tokens

### DIFF
--- a/dataquality/loggers/base_logger.py
+++ b/dataquality/loggers/base_logger.py
@@ -58,6 +58,7 @@ class BaseLoggerAttributes(str, Enum):
     log_helper_data = "log_helper_data"
     inference_name = "inference_name"
     image = "image"
+    token_label_str = "token_label_str"
     token_label_positions = "token_label_positions"
     token_label_offsets = "token_label_offsets"
     label = "label"

--- a/dataquality/loggers/data_logger/seq2seq/formatters.py
+++ b/dataquality/loggers/data_logger/seq2seq/formatters.py
@@ -266,15 +266,13 @@ class DecoderOnlyDataFormatter(BaseSeq2SeqDataFormatter):
             desc="Aligning string characters with tokenizer representation",
         ):
             # Detokenize to save the token_str in the df (for ex for high DEP tokens)
-            # Need to decode row by row otherwise each row is joined into one string
-            data_logger.token_label_str = [
+            data_logger.token_label_str.append(
                 tokenizer.batch_decode(
-                    row,
+                    token_label_ids,
                     skip_special_tokens=not use_special_tokens,
                     clean_up_tokenization_spaces=True,
                 )
-                for row in token_label_ids
-            ]
+            )
 
             aligned_data = align_response_tokens_to_character_spans(
                 tokenizer,

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -74,10 +74,14 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
 
     def __init__(self, meta: Optional[MetasType] = None) -> None:
         super().__init__(meta)
-        # Character offsets for each token (from tokenized_inputs) in the dataset
+        # The target tokens (as strings) coming out of the tokenizer
+        self.token_label_str: List[List[str]] = []
+        # Character offsets for each token in the target indicating at each character
+        # position each token starts and ends
         self.token_label_offsets: List[List[Tuple[int, int]]] = []
-        # Index (or indices) into the token array for every offset
+        # Index indicating the target tokens' position in the text (for every offset)
         self.token_label_positions: List[List[Set[int]]] = []
+
         self.ids: List[int] = []
         self.texts: List[str] = []
         self.labels: List[str] = []
@@ -152,6 +156,7 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
                 S2SIC.input.value: self.texts,
                 S2SIC.target.value: self.labels,
                 S2SIC.split_.value: [self.split] * len(self.ids),
+                S2SIC.token_label_str.value: pa.array(self.token_label_str),
                 S2SIC.token_label_positions.value: pa.array(self.token_label_positions),
                 S2SIC.token_label_offsets.value: pa.array(self.token_label_offsets),
                 **self.meta,

--- a/dataquality/schemas/seq2seq.py
+++ b/dataquality/schemas/seq2seq.py
@@ -32,6 +32,7 @@ class Seq2SeqInputCols(str, Enum):
     input_cutoff = "input_cutoff"
     target_cutoff = "target_cutoff"
     # Columns saved as pyarrow arrays
+    token_label_str = "token_label_str"
     token_label_positions = "token_label_positions"
     token_label_offsets = "token_label_offsets"
     system_prompts = "system_prompts"

--- a/tests/loggers/test_seq2seq.py
+++ b/tests/loggers/test_seq2seq.py
@@ -79,6 +79,7 @@ def test_log_dataset_encoder_decoder(
         "target",
         "token_label_positions",
         "token_label_offsets",
+        "token_label_str",
     ]
     assert sorted(df.get_column_names()) == sorted(expected_cols)
     assert df["input"].tolist() == ["summary 1", "summary 2", "summary 3"]


### PR DESCRIPTION
Goal is to compute high dep tokens https://app.shortcut.com/galileo/story/9232/dq-save-nessec-column-for-high-dep-tokens?vc_group_by=day&ct_workflow=all&cf_workflow=500000005

The DQ work requires saving the target tokens. We later groupby them (and the ID is not enough as we need the tokens for the UI).

Decoding the target token ids is fast enough in my opinion. Here it's taking ~10 sec for 10K rows and ~1M tokens 
![Screenshot 2023-11-28 at 10 17 41 AM](https://github.com/rungalileo/dataquality/assets/112427971/e71256c8-7d5b-4456-bdcf-ff58ba54d650).

