### PR TITLE
Clean up data `formaters`, removing need for passing `Seq2SeqDataLogger`

### DIFF
--- a/dataquality/loggers/data_logger/seq2seq/formatters.py
+++ b/dataquality/loggers/data_logger/seq2seq/formatters.py
@@ -34,6 +34,41 @@ class BaseSeq2SeqDataFormatter(ABC):
         max_tokens: Optional[int],
         split_key: str,
     ) -> Tuple[AlignedTokenData, List[List[str]]]:
+        """Tokenize and align the `text` samples
+
+        `format_text` tokenizes and computes token alignments for
+        each samples in `text`. Different logic is applied depending on the
+        model architecture (EncoderDecoder vs. DecoderOnly).
+
+        In the end, we return AlignedTokenData and the target token strings
+        (corresponding to `token_label_str` in `Seq2SeqDataLogger`). For both
+        EncoderDecoder and DecoderOnly models the output is expected
+        to be token alignment and string data over just the <Target> tokens
+        in the Seq2Seq task. Note though that the input `text` samples are
+        different between the two model architectures. See their respective
+        implementations for further details.
+
+        Additionally, we assign the necessary `self.logger_config`.
+
+        Parameters:
+        -----------
+        texts: List[str]
+            batch of str samples. For EncoderDecoder model's these are exactly
+            the targets vs. for DecoderOnly model's each sample is the full
+            formatted_prompt
+        ids: List[int]
+            sample ids - used for logger_config assignment
+        tokenizer: PreTrainedTokenizerFast
+        max_tokens: Optional[int]
+        split_key: str
+
+        Return:
+        -------
+        batch_aligned_data: AlignedTokenData
+            Aligned token data for *just* target tokens, based on `text`
+        token_label_str: List[List[str]]
+            The target tokens (as strings) - see `Seq2SeqDataLogger.token_label_str`
+        """
         pass
 
 

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -12,6 +12,9 @@ from dataquality.loggers.data_logger.base_data_logger import (
     DataSet,
     MetasType,
 )
+from dataquality.loggers.data_logger.seq2seq.formatters import (
+    get_data_formatter,
+)
 from dataquality.loggers.logger_config.seq2seq.seq2seq_base import (
     Seq2SeqLoggerConfig,
     seq2seq_logger_config,
@@ -90,10 +93,6 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
 
         self.formatter: Optional["BaseSeq2SeqDataFormatter"] = None
         if self.logger_config.model_type is not None:
-            from dataquality.loggers.data_logger.seq2seq.formatters import (
-                get_data_formatter,
-            )
-
             self.formatter = get_data_formatter(
                 self.logger_config.model_type, self.logger_config
             )

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -141,15 +141,16 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
             texts = self.labels
             max_tokens = self.logger_config.max_target_tokens
 
-        aligned_token_data = self.formatter.format_text(
+        batch_aligned_token_data, token_label_str = self.formatter.format_text(
             text=texts,
             ids=self.ids,
             tokenizer=self.logger_config.tokenizer,
             max_tokens=max_tokens,
             split_key=self.split_key,
         )
-        self.token_label_offsets = aligned_token_data.token_label_offsets
-        self.token_label_positions = aligned_token_data.token_label_positions
+        self.token_label_offsets = batch_aligned_token_data.token_label_offsets
+        self.token_label_positions = batch_aligned_token_data.token_label_positions
+        self.token_label_str = token_label_str
 
     def _get_input_df(self) -> DataFrame:
         data = vaex.from_dict(

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -138,12 +138,15 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
             texts = self.labels
             max_tokens = self.logger_config.max_target_tokens
 
-        self.formatter.format_text(
-            self.logger_config.tokenizer,
-            texts,
-            max_tokens,
-            self,
+        aligned_token_data = self.formatter.format_text(
+            text=texts,
+            ids=self.ids,
+            tokenizer=self.logger_config.tokenizer,
+            max_tokens=max_tokens,
+            split_key=self.split_key,
         )
+        self.token_label_offsets = aligned_token_data.token_label_offsets
+        self.token_label_positions = aligned_token_data.token_label_positions
 
     def _get_input_df(self) -> DataFrame:
         data = vaex.from_dict(

--- a/dataquality/schemas/seq2seq.py
+++ b/dataquality/schemas/seq2seq.py
@@ -71,6 +71,22 @@ class AlignedTokenData:
     token_label_offsets: List[List[Tuple[int, int]]]
     token_label_positions: List[List[Set[int]]]
 
+    def append(self, sample_aligned_token_data: "AlignedTokenData") -> None:
+        """Append offsets and positions for a *single* sample
+
+        Assumes that `sample_aligned_token_data` holds alignment info for
+        a single data sample. As such, when appending to `token_label_offsets`
+        and `token_label_positions` we remove the "batch" dimensions respectively.
+            e.g.
+            >> sample_aligned_token_data.token_label_offsets[0]
+        """
+        self.token_label_offsets.append(
+            sample_aligned_token_data.token_label_offsets[0]
+        )
+        self.token_label_positions.append(
+            sample_aligned_token_data.token_label_positions[0]
+        )
+
 
 @dataclass
 class LogprobData:

--- a/dataquality/schemas/seq2seq.py
+++ b/dataquality/schemas/seq2seq.py
@@ -72,21 +72,22 @@ class AlignedTokenData:
     token_label_offsets: List[List[Tuple[int, int]]]
     token_label_positions: List[List[Set[int]]]
 
-    def append(self, sample_aligned_token_data: "AlignedTokenData") -> None:
+    def append(self, aligned_token_data: "AlignedTokenData") -> None:
         """Append offsets and positions for a *single* sample
 
         Assumes that `sample_aligned_token_data` holds alignment info for
-        a single data sample. As such, when appending to `token_label_offsets`
+        a *single* data sample. As such, when appending to `token_label_offsets`
         and `token_label_positions` we remove the "batch" dimensions respectively.
             e.g.
             >> sample_aligned_token_data.token_label_offsets[0]
         """
-        self.token_label_offsets.append(
-            sample_aligned_token_data.token_label_offsets[0]
+        assert (
+            len(aligned_token_data.token_label_offsets) == 1
+            and len(aligned_token_data.token_label_positions) == 1
         )
-        self.token_label_positions.append(
-            sample_aligned_token_data.token_label_positions[0]
-        )
+
+        self.token_label_offsets.append(aligned_token_data.token_label_offsets[0])
+        self.token_label_positions.append(aligned_token_data.token_label_positions[0])
 
 
 @dataclass


### PR DESCRIPTION
***PR Description***

One of the current design choices for the `data_logger` formatters, was to pass the actual `Seq2SeqDataLogger` to the `.format()` function. This was nice for dev speed, but is not the nicest for three primary reason (that I see):
1. It can cause annoying trickiness around avoiding circular imports. For example, I am working on the generation PR for Decoder-Only models, and I want to use `data_formatters`; however, when I try to do so, I get circular import errors.
2. Overall it seems like not the greatest python "style".
3. It is not as necessary as we maybe initially thought.

To elaborate on point (3), you will see in this PR that we basically need to address two main issues when removing the dependance on having the actual `Seq2SeqDataLogger`:
1. Saving information to the `LoggerConfig`: Accomplished by passing in two additional data fields to the `format` function: a) `ids` and b) `split_key`
2. Assigning offsets and positions: Accomplished by returning the "formatted" `AlignedData` object. 

With these two fairly simple extensions we are able to simplify the `format(.)` function!

Note: One addition that we have to make is extending the `AlignedTokenData` class to have an `append(.)` function. This is necessary because for DecoderOnly models we process the aligned token data one sample at a time. The function we add is simple and follows this structure:
```
# The AlignedTokenData object that we are building up sample by sample
aligned_data: AlignedTokenData

# Aligned token data for a *single* sample - i.e. batch dim == 1
sample_aligned_token_data: AlignedTokenData

# This will append the `offset` and `position` data from the sample
# to the internal fields of `aligned_data`.
aligned_data.append(sample_aligned_token_data)
```