### PR TITLE
Decoder Only Generation Support

### DIFF
--- a/dataquality/loggers/data_logger/seq2seq/formatters.py
+++ b/dataquality/loggers/data_logger/seq2seq/formatters.py
@@ -8,10 +8,17 @@ from transformers import GenerationConfig, PreTrainedModel, PreTrainedTokenizerF
 from vaex import DataFrame
 
 from dataquality.loggers.logger_config.seq2seq.seq2seq_base import Seq2SeqLoggerConfig
-from dataquality.schemas.seq2seq import AlignedTokenData, ModelGeneration, Seq2SeqModelType
+from dataquality.schemas.seq2seq import (
+    AlignedTokenData,
+    ModelGeneration,
+    Seq2SeqModelType,
+)
 from dataquality.schemas.seq2seq import Seq2SeqInputCols as S2SIC
 from dataquality.utils.seq2seq.decoder_only import extract_tokenized_responses
-from dataquality.utils.seq2seq.logprobs import get_top_logprob_indices, process_sample_logprobs
+from dataquality.utils.seq2seq.logprobs import (
+    get_top_logprob_indices,
+    process_sample_logprobs,
+)
 from dataquality.utils.seq2seq.offsets import (
     add_input_cutoff_to_df,
     add_target_cutoff_to_df,
@@ -121,12 +128,14 @@ class BaseSeq2SeqDataFormatter(ABC):
 
     @staticmethod
     def process_generated_logits(
-            generated_logits: torch.Tensor,
-            generated_ids: np.ndarray,
-            tokenizer: PreTrainedTokenizerFast,
+        generated_logits: torch.Tensor,
+        generated_ids: np.ndarray,
+        tokenizer: PreTrainedTokenizerFast,
     ) -> ModelGeneration:
         # import pdb; pdb.set_trace()
-        logprobs = torch.nn.functional.log_softmax(generated_logits, dim=-1).cpu().numpy()
+        logprobs = (
+            torch.nn.functional.log_softmax(generated_logits, dim=-1).cpu().numpy()
+        )
         top_logprobs_indices = get_top_logprob_indices(logprobs)
 
         gen_logprob_data = process_sample_logprobs(
@@ -221,7 +230,6 @@ class EncoderDecoderDataFormatter(BaseSeq2SeqDataFormatter):
                 sample id to tokenized label (sample_id -> List[token_id])
         """
         targets = text
-        max_target_tokens = max_tokens
         use_special_tokens = True  # use this var to align encoding and decoding
         encoded_data = tokenizer(
             targets,

--- a/dataquality/loggers/data_logger/seq2seq/formatters.py
+++ b/dataquality/loggers/data_logger/seq2seq/formatters.py
@@ -490,10 +490,12 @@ class DecoderOnlyDataFormatter(BaseSeq2SeqDataFormatter):
             return_tensors="pt",
         )["input_ids"]
 
-        len_prompt_ids_without_response = len(formatted_prompt_ids[0]) - num_response_labels
-        prompt_ids_without_response = formatted_prompt_ids[:, :len_prompt_ids_without_response].to(
-            model.device
+        len_prompt_ids_without_response = (
+            len(formatted_prompt_ids[0]) - num_response_labels
         )
+        prompt_ids_without_response = formatted_prompt_ids[
+            :, :len_prompt_ids_without_response
+        ].to(model.device)
 
         # This returns ALL the ids (prompt + response)
         full_gen_ids = model.generate(

--- a/dataquality/loggers/data_logger/seq2seq/formatters.py
+++ b/dataquality/loggers/data_logger/seq2seq/formatters.py
@@ -132,7 +132,6 @@ class BaseSeq2SeqDataFormatter(ABC):
         generated_ids: np.ndarray,
         tokenizer: PreTrainedTokenizerFast,
     ) -> ModelGeneration:
-        # import pdb; pdb.set_trace()
         logprobs = (
             torch.nn.functional.log_softmax(generated_logits, dim=-1).cpu().numpy()
         )

--- a/dataquality/loggers/data_logger/seq2seq/formatters.py
+++ b/dataquality/loggers/data_logger/seq2seq/formatters.py
@@ -112,7 +112,8 @@ class BaseSeq2SeqDataFormatter(ABC):
         input_str: str
             Input string context used to seed the generation
         tokenizer: PreTrainedTokenizerFast
-        max_input_tokens: the max number of tokens to use for tokenization
+        max_input_tokens: int
+            the max number of tokens to use for tokenization
         model: PreTrainedModel
         generation_config: GenerationConfig
             Users generation config specifying the parameters for generation

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -13,8 +13,9 @@ from dataquality.loggers.data_logger.base_data_logger import (
     MetasType,
 )
 from dataquality.loggers.data_logger.seq2seq.formatters import (
-    get_data_formatter,
+    BaseSeq2SeqDataFormatter, get_data_formatter,
 )
+
 from dataquality.loggers.logger_config.seq2seq.seq2seq_base import (
     Seq2SeqLoggerConfig,
     seq2seq_logger_config,
@@ -91,11 +92,8 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         # Only required for Decoder-Only models
         self.formatted_prompts: List[str] = []
         # Formatter distinguishes behavior between EncoderDecoder and DecoderOnly
-        from dataquality.loggers.data_logger.seq2seq.formatters import (
-            BaseSeq2SeqDataFormatter,
-        )
 
-        self.formatter: Optional["BaseSeq2SeqDataFormatter"] = None
+        self.formatter: Optional[BaseSeq2SeqDataFormatter] = None
         if self.logger_config.model_type is not None:
             self.formatter = get_data_formatter(
                 self.logger_config.model_type, self.logger_config
@@ -157,8 +155,8 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
     def _get_input_df(self) -> DataFrame:
         df_dict = {
             S2SIC.id.value: self.ids,
-            S2SIC.text.value: self.texts,
-            S2SIC.label.value: self.labels,
+            S2SIC.input.value: self.texts,
+            S2SIC.target.value: self.labels,
             S2SIC.split_.value: [self.split] * len(self.ids),
             S2SIC.token_label_positions.value: pa.array(self.token_label_positions),
             S2SIC.token_label_offsets.value: pa.array(self.token_label_offsets),
@@ -327,7 +325,7 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         assert generation_config is not None
         print(f"Generating {len(df)} samples for split {split}")
         # Need to specify the column to generate over!
-        generation_column = S2SIC.text.value
+        generation_column = S2SIC.target.value
         if self.logger_config.model_type == Seq2SeqModelType.decoder_only:
             generation_column = S2SIC.formatted_prompts.value
 

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -344,7 +344,8 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
             split_key=split,
         )
         # The formatted_prompts column is no longer needed
-        df = df.drop([S2SIC.formatted_prompts])
+        if S2SIC.formatted_prompts in df.get_column_names():
+            df = df.drop([S2SIC.formatted_prompts])
 
         return df
 

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -159,6 +159,7 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
             S2SIC.split_.value: [self.split] * len(self.ids),
             S2SIC.token_label_positions.value: pa.array(self.token_label_positions),
             S2SIC.token_label_offsets.value: pa.array(self.token_label_offsets),
+            S2SIC.token_label_str.value: pa.array(self.token_label_str),
             **self.meta,
         }
         if len(self.formatted_prompts) != 0:

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -22,6 +22,7 @@ from dataquality.loggers.logger_config.seq2seq.seq2seq_base import (
 )
 from dataquality.schemas.dataframe import BaseLoggerDataFrames
 from dataquality.schemas.seq2seq import Seq2SeqInputCols as S2SIC
+from dataquality.schemas.seq2seq import Seq2SeqInputTempCols as S2SITC
 from dataquality.schemas.seq2seq import Seq2SeqModelType
 from dataquality.schemas.split import Split
 from dataquality.utils.emb import convert_pa_to_np
@@ -163,7 +164,7 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
             **self.meta,
         }
         if len(self.formatted_prompts) != 0:
-            df_dict[S2SIC.formatted_prompts.value] = self.formatted_prompts
+            df_dict[S2SITC.formatted_prompts.value] = self.formatted_prompts
 
         data = vaex.from_dict(df_dict)
 
@@ -183,8 +184,8 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         # Inference case
         if S2SIC.target in df:
             self.labels = df[S2SIC.target].tolist()
-        if S2SIC.formatted_prompts in df:
-            self.formatted_prompts = df[S2SIC.formatted_prompts].tolist()
+        if S2SITC.formatted_prompts in df:
+            self.formatted_prompts = df[S2SITC.formatted_prompts].tolist()
         for meta_col in meta or []:
             self.meta[str(meta_col)] = df[meta_col].tolist()
         self.log()
@@ -286,7 +287,7 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         for text_col in [
             S2SIC.input.value,
             S2SIC.target.value,
-            S2SIC.formatted_prompts.value,
+            S2SITC.formatted_prompts.value,
         ]:
             if text_col in df_copy.get_column_names():
                 # Characters are each 1 byte. If more bytes > max,
@@ -332,7 +333,7 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         # Need to specify the column to generate over!
         generation_column = S2SIC.target.value
         if self.logger_config.model_type == Seq2SeqModelType.decoder_only:
-            generation_column = S2SIC.formatted_prompts.value
+            generation_column = S2SITC.formatted_prompts.value
 
         df = add_generated_output_to_df(
             df,
@@ -344,9 +345,6 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
             generation_config=generation_config,
             split_key=split,
         )
-        # The formatted_prompts column is no longer needed
-        if S2SIC.formatted_prompts in df.get_column_names():
-            df = df.drop([S2SIC.formatted_prompts])
 
         return df
 

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -213,12 +213,12 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
             column_map[label] = "target"
         if isinstance(dataset, pd.DataFrame):
             if formatted_prompt and formatted_prompt in dataset.columns:
-                column_map[formatted_prompt] = "galileo_formatted_prompt"
+                column_map[formatted_prompt] = S2SITC.formatted_prompts
             dataset = dataset.rename(columns=column_map)
             self._log_df(dataset, meta)
         elif isinstance(dataset, DataFrame):
             if formatted_prompt and formatted_prompt in dataset.get_column_names():
-                column_map[formatted_prompt] = "galileo_formatted_prompt"
+                column_map[formatted_prompt] = S2SITC.formatted_prompts
             for chunk in range(0, len(dataset), batch_size):
                 chunk_df = dataset[chunk : chunk + batch_size]
                 chunk_df = rename_df(chunk_df, column_map)
@@ -226,7 +226,7 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         elif self.is_hf_dataset(dataset):
             ds = cast("Dataset", dataset)  # For typing
             if formatted_prompt and formatted_prompt in ds.column_names:
-                column_map[formatted_prompt] = "galileo_formatted_prompt"
+                column_map[formatted_prompt] = S2SITC.formatted_prompts
             for chunk in range(0, len(ds), batch_size):
                 chunk = ds[chunk : chunk + batch_size]
                 chunk_df = pd.DataFrame(chunk)
@@ -283,7 +283,6 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         See BaseDataLogger.convert_large_string for more details
         """
         df_copy = df.copy()
-        # TODO Include formatted prompt?
         for text_col in [
             S2SIC.input.value,
             S2SIC.target.value,
@@ -305,7 +304,6 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         Adds the generated output to the dataframe, and also adds the
         `token_label_positions` column
         """
-        # logger_config = cls.logger_config
         if split not in self.logger_config.generation_splits:
             return df
 

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -177,13 +177,13 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         meta: Union[List[str], List[int], None] = None,
     ) -> None:
         """Helper to log a pandas or vaex df"""
-        self.texts = df["input"].tolist()
-        self.ids = df["id"].tolist()
+        self.texts = df[S2SIC.input].tolist()
+        self.ids = df[S2SIC.id].tolist()
         # Inference case
-        if "target" in df:
-            self.labels = df["target"].tolist()
-        if "galileo_formatted_prompt" in df:
-            self.formatted_prompts = df["galileo_formatted_prompt"].tolist()
+        if S2SIC.target in df:
+            self.labels = df[S2SIC.target].tolist()
+        if S2SIC.formatted_prompts in df:
+            self.formatted_prompts = df[S2SIC.formatted_prompts].tolist()
         for meta_col in meta or []:
             self.meta[str(meta_col)] = df[meta_col].tolist()
         self.log()

--- a/dataquality/loggers/model_logger/base_model_logger.py
+++ b/dataquality/loggers/model_logger/base_model_logger.py
@@ -16,6 +16,7 @@ from dataquality.schemas.split import Split
 from dataquality.schemas.task_type import TaskType
 from dataquality.utils.dq_logger import get_dq_logger
 from dataquality.utils.hdf5_store import _save_hdf5_file
+from dataquality.utils.thread_pool import ThreadPoolManager
 
 analytics = Analytics(ApiClient, config)  # type: ignore
 
@@ -110,8 +111,7 @@ class BaseGalileoModelLogger(BaseGalileoLogger):
         # global variables (cur_split and cur_epoch) that are subject to change
         # between subsequent threads
         self.set_split_epoch()
-        # ThreadPoolManager.add_thread(target=self._add_threaded_log)
-        self._add_threaded_log()
+        ThreadPoolManager.add_thread(target=self._add_threaded_log)
 
     def write_model_output(self, data: Dict) -> None:
         """Creates an hdf5 file from the data dict"""

--- a/dataquality/loggers/model_logger/base_model_logger.py
+++ b/dataquality/loggers/model_logger/base_model_logger.py
@@ -16,7 +16,6 @@ from dataquality.schemas.split import Split
 from dataquality.schemas.task_type import TaskType
 from dataquality.utils.dq_logger import get_dq_logger
 from dataquality.utils.hdf5_store import _save_hdf5_file
-from dataquality.utils.thread_pool import ThreadPoolManager
 
 analytics = Analytics(ApiClient, config)  # type: ignore
 
@@ -111,7 +110,8 @@ class BaseGalileoModelLogger(BaseGalileoLogger):
         # global variables (cur_split and cur_epoch) that are subject to change
         # between subsequent threads
         self.set_split_epoch()
-        ThreadPoolManager.add_thread(target=self._add_threaded_log)
+        # ThreadPoolManager.add_thread(target=self._add_threaded_log)
+        self._add_threaded_log()
 
     def write_model_output(self, data: Dict) -> None:
         """Creates an hdf5 file from the data dict"""

--- a/dataquality/schemas/seq2seq.py
+++ b/dataquality/schemas/seq2seq.py
@@ -38,6 +38,7 @@ class Seq2SeqInputCols(str, Enum):
     token_label_positions = "token_label_positions"
     token_label_offsets = "token_label_offsets"
     system_prompts = "system_prompts"
+    formatted_prompts = "galileo_formatted_prompts"
 
     @classmethod
     def set_cols(cls, df: DataFrame) -> DataFrame:

--- a/dataquality/schemas/seq2seq.py
+++ b/dataquality/schemas/seq2seq.py
@@ -36,6 +36,9 @@ class Seq2SeqInputCols(str, Enum):
     token_label_positions = "token_label_positions"
     token_label_offsets = "token_label_offsets"
     system_prompts = "system_prompts"
+
+
+class Seq2SeqInputTempCols(str, Enum):
     formatted_prompts = "galileo_formatted_prompts"
 
 

--- a/dataquality/utils/seq2seq/decoder_only.py
+++ b/dataquality/utils/seq2seq/decoder_only.py
@@ -9,9 +9,22 @@ def isolate_response_tokens(
     tokenized_formatted_prompt: List[int], response_template: List[int]
 ) -> List[int]:
     """Identify the final instance of the response_template and use that to isolate just
-    the response tokens
+    the response tokens.
 
-    tokenized_formatted_prompt - shape = [num_tokens]
+    tokenized_formatted_prompt has = [num_tokens]
+
+    We search for the *final* occurrence of the response_template within the formatted
+    prompt through sublist matching. After isolating the final response_template, we
+    slice off the remaining tokens, representing the tokenized response.
+
+    Example:
+          >> tokenized_formatted_prompt = [[7, 1, 2, 3, 8, 5, 9, 1, 2, 3, 9, 10, 6]]
+          >> response_template = [1, 2, 3]
+          >> extract_tokenized_responses(tokenized_formatted_prompt, response_template)
+            [[9, 10, 6]]
+
+    If a sample does not contain the response_template we represent the
+    tokenized_response for that sample as [] - i.e. the <Empty String>.
     """
     # Reverse search over matches of the first token in the response template
     matched_indices = np.where(
@@ -53,22 +66,7 @@ def extract_tokenized_responses(
 ) -> List[List[int]]:
     """Extracts the tokenized responses from the formatted prompts
 
-    TODO Upate
-    For each sample, we search for the *final* occurrence of the
-    response_template within the formatted prompt - through
-    sublist matching.
-
-    After isolating the final response_template, we slice off
-    the remaining tokens, representing the tokenized response.
-
-    Example:
-          >> tokenized_formatted_prompt = [[7, 1, 2, 3, 8, 5, 9, 1, 2, 3, 9, 10, 6]]
-          >> response_template = [1, 2, 3]
-          >> extract_tokenized_responses(tokenized_formatted_prompt, response_template)
-            [[9, 10, 6]]
-
-    If a sample does not contain the response_template we represent the
-    tokenized_response for that sample as [] - i.e. the <Empty String>.
+    For each sample, we isolate the response (from the input) and return it.
     """
     tokenized_responses: List[List[int]] = []
     for t_prompt in tqdm(

--- a/dataquality/utils/seq2seq/decoder_only.py
+++ b/dataquality/utils/seq2seq/decoder_only.py
@@ -31,8 +31,8 @@ def isolate_response_tokens(
         np.array(tokenized_formatted_prompt) == response_template[0]
     )[0]
     response_token_ids_start_idx = None
-    for i in range(len(matched_indices)):
-        match_idx = matched_indices[-(i + 1)]
+    for match_idx in reversed(matched_indices):
+        # match_idx = matched_indices[-(i + 1)]
         # Check for exact match of the response template token ids.
         # Once found break to avoid finding further matches + short-circuit
         # search.

--- a/dataquality/utils/seq2seq/decoder_only.py
+++ b/dataquality/utils/seq2seq/decoder_only.py
@@ -5,11 +5,55 @@ import numpy as np
 from tqdm.auto import tqdm
 
 
+def isolate_response_tokens(
+    tokenized_formatted_prompt: List[int], response_template: List[int]
+) -> List[int]:
+    """Identify the final instance of the response_template and use that to isolate just
+    the response tokens
+
+    tokenized_formatted_prompt - shape = [num_tokens]
+    """
+    # Reverse search over matches of the first token in the response template
+    matched_indices = np.where(
+        np.array(tokenized_formatted_prompt) == response_template[0]
+    )[0]
+    response_token_ids_start_idx = None
+    for i in range(len(matched_indices)):
+        match_idx = matched_indices[-(i + 1)]
+        # Check for exact match of the response template token ids.
+        # Once found break to avoid finding further matches + short-circuit
+        # search.
+        if (
+            tokenized_formatted_prompt[match_idx : match_idx + len(response_template)]
+            == response_template
+        ):
+            response_token_ids_start_idx = match_idx
+            break
+
+    tokenized_response = []
+    # Warn that the response template was not found!
+    if response_token_ids_start_idx is None:
+        warn(
+            f"Could not find response key `{response_template}` in the "
+            f"following instance: `{tokenized_formatted_prompt}`. "
+            f"This instance will have an <Empty> Target Output. "
+            f"Note, if this happens often, consider increasing `max_seq_length`."
+        )
+    else:
+        response_token_ids_end_idx = response_token_ids_start_idx + len(
+            response_template
+        )
+        tokenized_response = tokenized_formatted_prompt[response_token_ids_end_idx:]
+
+    return tokenized_response
+
+
 def extract_tokenized_responses(
     tokenized_formatted_prompts: List[List[int]], response_template: List[int]
 ) -> List[List[int]]:
     """Extracts the tokenized responses from the formatted prompts
 
+    TODO Upate
     For each sample, we search for the *final* occurrence of the
     response_template within the formatted prompt - through
     sublist matching.
@@ -32,36 +76,7 @@ def extract_tokenized_responses(
         leave=False,
         desc="Identifying `response_template` to isolate response token.",
     ):
-        # Reverse search over matches of the first token in the response template
-        matched_indices = np.where(np.array(t_prompt) == response_template[0])[0]
-        response_token_ids_start_idx = None
-        for i in range(len(matched_indices)):
-            match_idx = matched_indices[-(i + 1)]
-            # Check for exact match of the response template token ids.
-            # Once found break to avoid finding further matches + short-circuit
-            # search.
-            if (
-                t_prompt[match_idx : match_idx + len(response_template)]
-                == response_template
-            ):
-                response_token_ids_start_idx = match_idx
-                break
-
-        tokenized_response = []
-        # Warn that the response template was not found!
-        if response_token_ids_start_idx is None:
-            warn(
-                f"Could not find response key `{response_template}` in the "
-                f"following instance: `{t_prompt}`. "
-                f"This instance will have an <Empty> Target Output. "
-                f"Note, if this happens often, consider increasing `max_seq_length`."
-            )
-        else:
-            response_token_ids_end_idx = response_token_ids_start_idx + len(
-                response_template
-            )
-            tokenized_response = t_prompt[response_token_ids_end_idx:]
-
+        tokenized_response = isolate_response_tokens(t_prompt, response_template)
         tokenized_responses.append(tokenized_response)
 
     return tokenized_responses

--- a/dataquality/utils/seq2seq/generation.py
+++ b/dataquality/utils/seq2seq/generation.py
@@ -59,7 +59,7 @@ def generate_on_batch(
             model=model,
             max_input_tokens=max_input_tokens,
             generation_config=generation_config,
-            input_id=int(sample_id),
+            input_id=sample_id.as_py(),  # Convert to int from pyarrow type
             split_key=split_key,
         )
 

--- a/dataquality/utils/seq2seq/generation.py
+++ b/dataquality/utils/seq2seq/generation.py
@@ -59,7 +59,7 @@ def generate_on_batch(
             model=model,
             max_input_tokens=max_input_tokens,
             generation_config=generation_config,
-            input_id=sample_id.as_py(),
+            input_id=int(sample_id),
             split_key=split_key,
         )
 

--- a/docs/notebooks/Seq2Seq_Decoder_Only_Dq_Fake_Data.ipynb
+++ b/docs/notebooks/Seq2Seq_Decoder_Only_Dq_Fake_Data.ipynb
@@ -81,14 +81,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_size = 100\n",
+    "dataset_size = 10\n",
     "\n",
     "ds = load_dataset(\"billsum\")\n",
     "ds = ds.remove_columns('text')\n",
     "# Add ids\n",
     "ds = ds.map(create_formatted_prompt, with_indices=True)\n",
-    "ds_train = Dataset.from_dict(ds['train'][:100])\n",
-    "ds_val = Dataset.from_dict(ds['test'][:100])\n",
+    "ds_train = Dataset.from_dict(ds['train'][:dataset_size])\n",
+    "ds_val = Dataset.from_dict(ds['test'][:dataset_size])\n",
     "ds_train"
    ]
   },
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import AutoTokenizer, GenerationConfig, AutoModelForCausalLM\n",
+    "from transformers import AutoTokenizer, GenerationConfig, AutoModelForCausalLM, PreTrainedTokenizerFast\n",
     "\n",
     "tokenizer = AutoTokenizer.from_pretrained(\"facebook/opt-125m\", use_fast=True)\n",
     "model = AutoModelForCausalLM.from_pretrained(\"facebook/opt-125m\")"
@@ -143,60 +143,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e63464a5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "batch = ds_train[:10]\n",
-    "model_inputs = {\n",
-    "    'input_ids': batch['input_ids'],\n",
-    "    'attention_mask': batch['attention_mask'],\n",
-    "    #'labels': batch['input_ids'].copy()\n",
-    "}\n",
-    "model_inputs = tokenizer.pad(model_inputs, padding=True, return_tensors='pt')\n",
-    "model_inputs['labels'] = model_inputs['input_ids'].clone()\n",
-    "model_outputs = model(**model_inputs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4f52621a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_outputs.logits.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0c9cb17b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import torch\n",
-    "\n",
-    "\n",
-    "fake_sample_ids = torch.tensor([[2, 337, 245, 103, 63, 839, 215, 239]])\n",
-    "fake_attention = torch.ones(1, 8)\n",
-    "fake_labels = fake_sample_ids.clone()\n",
-    "model_outputs = model(input_ids=fake_sample_ids, attention_mask=fake_attention, labels=fake_labels)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "07256adb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_outputs.logits.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "def75c6f",
    "metadata": {},
    "outputs": [],
@@ -218,9 +164,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dq.init(\"seq2seq\", project_name=\"Seq2Seq_DecoderOnly_Real_Model_shifted\")\n",
+    "dq.init(\"seq2seq\", project_name=\"Seq2Seq_DecoderOnly_Generation\")\n",
     "\n",
-    "temperature = 0.4\n",
+    "temperature = 0.\n",
     "generation_config = GenerationConfig(\n",
     "    max_new_tokens=15,\n",
     "    # Whether we use multinomial sampling\n",
@@ -228,11 +174,15 @@
     "    temperature=temperature,\n",
     ")\n",
     "\n",
+    "response_template = \"###Response:\"\n",
+    "response_template = tokenizer(response_template, add_special_tokens=False)[\"input_ids\"]\n",
+    "\n",
     "watch(\n",
-    "    model,\n",
     "    tokenizer,\n",
+    "    \"decoder_only\",\n",
+    "    model,\n",
     "    generation_config,\n",
-    "    generation_splits=[],\n",
+    "    generation_splits=['train'],\n",
     "    max_input_tokens=1024,\n",
     "    response_template=response_template\n",
     ")"

--- a/tests/loggers/conftest.py
+++ b/tests/loggers/conftest.py
@@ -66,5 +66,5 @@ def create_logger(tab_data: Dict, fit_xgboost: xgb.XGBClassifier) -> Callable:
 
 
 @pytest.fixture
-def seq2seq_generated_output() -> torch.Tensor:
-    return torch.tensor([[1, 2, 3], [4, 5, 6]])
+def seq2seq_generated_sample_output() -> torch.Tensor:
+    return torch.tensor([[1, 2, 3, 4, 5, 6]])

--- a/tests/loggers/test_seq2seq.py
+++ b/tests/loggers/test_seq2seq.py
@@ -301,12 +301,14 @@ def test_add_generated_output_to_df(
     # Create fake df with vaex
     num_batches = 10
     df_size = batch_size * num_batches
-    df = vaex.from_dict({"input": ["Fake Input"] * df_size})
+    df = vaex.from_dict({"input": ["Fake Input"] * df_size, "id": list(range(df_size))})
 
     with patch(
         "dataquality.utils.seq2seq.generation.GENERATION_BATCH_SIZE", batch_size
     ):
-        df = add_generated_output_to_df(df, Mock(), Mock(), 512, Mock())
+        df = add_generated_output_to_df(
+            df, "input", Mock(), Mock(), Mock(), 512, Mock()
+        )
 
     # Check the df columns!
     assert len(df) == df_size

--- a/tests/utils/test_seq2seq_utils.py
+++ b/tests/utils/test_seq2seq_utils.py
@@ -99,7 +99,7 @@ def test_generate_on_batch(
         model=mock_model,
         tokenizer=mock_tokenizer,
         formatter=mock_formatter,
-        ids=list(range(100)),
+        ids=pa.array(list(range(100))),
         max_input_tokens=mock_max_input_tokens,
         generation_config=mock_generation_config,
     )


### PR DESCRIPTION
## Description

In this PR we focus on adding generation support for Decoder Only models. In doing so, we also re-structure parts of the generation workflow. Below is an executive summary of the changes added!

The primary differences between generation for EncoderDecoder and DecoderOnly models are:
1. The df column / sample data used for generation
2. The generation processing for each sample (i.e. the logic previously in the `utils.seq2seq.generation.generate_sample_output` function).

Thankfully, similar to the processing of model logprob outputs, after sample level generation / processing, logic can be shared around token alignment and the overall saving of information to the dataframe - since in the end we expect the same information for generated data.

**The main structural change is to address (2) from above.**

To do this we leverage the `BaseSeq2SeqDataFormatter` class and define a new function `generate_sample` that is is over-written by `EncoderDecoderDataFormatter` and `DecoderOnlyDataFormatter`. Since generation occurs within `Seq2SeqDataLogger`, when we call `generation.add_generated_output_to_df` (from `Seq2SeqDataLogger.add_generated_output_to_df`), we now pass along the correct `formatter`. Then within `generation.generate_on_batch`, in place of calling `generate_sample_output` we call the respective `formatter.generate_sample`. 

The above description gives a high level intuition for the big changes in code structure. Additionally, there are some new parameters needed for generation with DecoderOnly models, such as the `sample_id` we are generating on (necessary to help isolate just the "input prompt" prompt to the model by removing the response tokens). 

**Addressing Difference (1)**
This is a fairly simple but important difference. 
- EncoderDecoder models can directly use the `Input` text column for generation.
- DecoderOnly models need the `formatted_prompt` text column to account for additional prompt formatting applied to the `Input` / `Target` pair.

**Additional Things to Note**
When first testing, I noticed that I was having a strange off by 1 error in the alignment. Essentially, the top-5 tokens for each "word" were actually the top-5 tokens for the next word. 

The problem ended up being that the tokenizer I was using added a `<bos>` token by default. However, for DecoderOnly models, although I am aligning just the generated tokens / string, I do so "as if" it were directly pre-fixed by the prompt. Therefore, I do not want any `<bos>` tokens added because I do not have logits for these, and thus the token alignments were shifted by one!

If the above does not immediately make much sense that is okay. The main takeaway is that within `utils.seq2seq.generation.generate_on_batch`, I explicitly decode and tokenize without adding *or* removing special tokens - i.e. I use exactly the generated ids - to avoid alignment issues. Additionally, this issue pointed me to potential challenges if tokenizers add <bos> tokens that we should test for when adding test completeness.

## Demonstration

You should now be able to generate using the `Seq2Seq_Decoder_Only_Dq_Fake_Data` notebook.

Here is an example [run](https://console.dev.rungalileo.io/insights/8de23502-d6cc-44a5-8452-0999ff6d6c92/cf1b9db4-fa8f-436f-8f2c-4b4af55406c5?dataframeColumns=bleu%3B%26data_error_potential%3B%26generated_output%3B%26generated_token_logprobs%3B%26generated_uncertainty%3B%26input%3B%26perplexity%3B%26rouge%3B%26target&groupedBy=galileo_input_length&taskType=8).