### PR TITLE
fix: disallow emb cols as metadata

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/loggers/base_logger.py
+++ b/dataquality/loggers/base_logger.py
@@ -74,6 +74,11 @@ class BaseLoggerAttributes(str, Enum):
     input_cutoff = "input_cutoff"
     target_cutoff = "target_cutoff"
     system_prompts = "system_prompts"
+    # Embedding attributes
+    x = "x"
+    y = "y"
+    data_x = "data_x"
+    data_y = "data_y"
 
     @staticmethod
     def get_valid() -> List[str]:

--- a/tests/test_dataquality.py
+++ b/tests/test_dataquality.py
@@ -207,6 +207,29 @@ def test_metadata_logging_invalid(
     assert len(c.meta) == MAX_META_COLS
 
 
+def test_metadata_logging_invalid_with_x_and_y(
+    cleanup_after_use: Callable, set_test_config: Callable
+) -> None:
+    """
+    Tests our metadata logging validation
+    """
+    meta = {
+        "x": [random() for _ in range(NUM_RECORDS * NUM_LOGS)],  # Reserved key
+        "y": [random() for _ in range(NUM_RECORDS * NUM_LOGS)],  # Reserved key
+        "data_x": [random() for _ in range(NUM_RECORDS * NUM_LOGS)],  # Reserved key
+        "data_y": [random() for _ in range(NUM_RECORDS * NUM_LOGS)],  # Reserved key
+    }
+
+    c = dataquality.get_data_logger("text_classification")
+    c.meta = meta
+    with pytest.warns(GalileoWarning) as gw:
+        c.validate_metadata(NUM_RECORDS * NUM_LOGS)
+
+    assert len(list(gw)) == 4
+    # All 4 columns should have been removed
+    assert c.meta == {}
+
+
 def test_logging_duplicate_ids(
     cleanup_after_use: Callable, set_test_config: Callable
 ) -> None:


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/9579/dq-adding-x-y-data-x-or-data-y-as-metadata-succeeds-but-should-not

Customer ran into issues when logging x as metadata 