### PR TITLE
fix: bump datasets to 2.14.6

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 import sys
 from typing import Any, List, Optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ test = [
     "fastai>=2.7.11",
     "portalocker==2.7.0",
     "types-PyYAML==6.0.12.9",
-    "setfit",
+    "setfit==0.7.0",
     "accelerate>=0.19.0",
     "typing-inspect==0.8.0",
     "typing-extensions==4.0.1",
@@ -111,7 +111,7 @@ minio = [
     "minio>=7.1.0,<7.2.0"
 ]
 setfit = [
-    "setfit"
+    "setfit==0.7.0"
 ]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "scipy>=1.7.0",
     "cachetools>=4.2.4",
     "importlib-metadata<6.0.1",
-    "datasets>=2.6",
+    "datasets>=2.14.6",
     "transformers>=4.17.0",
     "seqeval",
     "sentence-transformers>=2.2",


### PR DESCRIPTION
Fix IC integrations tests that are failing here https://github.com/rungalileo/deploy/actions/runs/7113620750/job/19365964373

Context: 
https://stackoverflow.com/questions/77433096/notimplementederror-loading-a-dataset-cached-in-a-localfilesystem-is-not-suppor