### PR TITLE
feat: token refresh

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.3.9"
+__version__ = "1.4.0"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/clients/api.py
+++ b/dataquality/clients/api.py
@@ -21,7 +21,7 @@ from dataquality.utils.auth import headers
 
 
 class ApiClient:
-    def refresh_token(self) -> None:
+    def _refresh_token(self) -> str:
         username = os.getenv("GALILEO_USERNAME")
         password = os.getenv("GALILEO_PASSWORD")
         if username is None or password is None:
@@ -53,10 +53,10 @@ class ApiClient:
         config.update_file_config()
         return access_token
 
-    def get_token(self) -> None:
+    def get_token(self) -> str:
         token = config.token
         if not token:
-            token = self.refresh_token()
+            token = self._refresh_token()
 
         # Check to see if our token is expired before making a request
         # and refresh token if it's expired
@@ -64,7 +64,7 @@ class ApiClient:
         if token:
             claims = jwt.decode(token, options={"verify_signature": False})
             if claims.get("exp", 0) < time():
-                token = self.refresh_token()
+                token = self._refresh_token()
 
         return token
 

--- a/dataquality/core/auth.py
+++ b/dataquality/core/auth.py
@@ -15,32 +15,12 @@ api_client = ApiClient()
 
 
 class _Auth:
-    def email_login(self) -> None:
-        username = os.getenv("GALILEO_USERNAME")
-        password = os.getenv("GALILEO_PASSWORD")
-        res = requests.post(
-            f"{config.api_url}/login",
-            data={
-                "username": username,
-                "password": password,
-                "auth_method": "email",
-            },
-            headers={"X-Galileo-Request-Source": "dataquality_python_client"},
-        )
-        if res.status_code != 200:
-            raise GalileoException(
-                (
-                    f"Issue authenticating: {res.json()['detail']} "
-                    "If you need to reset your password, "
-                    f"go to {config.api_url.replace('api', 'console')}/forgot-password"
-                )
-            )
+    def login_with_env_vars(self) -> None:
+        """Automatically log in with environment variables."""
+        api_client.get_token()
 
-        access_token = res.json().get("access_token")
-        config.token = access_token
-        config.update_file_config()
-
-    def token_login(self) -> None:
+    def login_with_token(self) -> None:
+        """Prompts a user to copy and paste a token from the console."""
         if url_is_localhost(url=config.api_url):
             token_url = f"{os.environ['GALILEO_CONSOLE_URL']}/{Route.token}"
         else:
@@ -76,9 +56,9 @@ def login() -> None:
 
     _auth = _Auth()
     if os.getenv("GALILEO_USERNAME") and os.getenv("GALILEO_PASSWORD"):
-        _auth.email_login()
+        _auth.login_with_env_vars()
     else:
-        _auth.token_login()
+        _auth.login_with_token()
 
     current_user_email = api_client.get_current_user().get("email")
     if not current_user_email:

--- a/dataquality/core/auth.py
+++ b/dataquality/core/auth.py
@@ -2,11 +2,8 @@ import getpass
 import os
 import webbrowser
 
-import requests
-
 from dataquality.clients.api import ApiClient
 from dataquality.core._config import config, url_is_localhost
-from dataquality.exceptions import GalileoException
 from dataquality.schemas.route import Route
 from dataquality.utils.helpers import check_noop
 

--- a/dataquality/utils/auth.py
+++ b/dataquality/utils/auth.py
@@ -2,10 +2,7 @@ from typing import Dict, Optional
 
 
 def headers(token: Optional[str]) -> Dict[str, str]:
-    """Return authorization headers for API requests
-
-    If token is expired, attempt to refresh it.
-    """
+    """Return authorization headers for API requests"""
     if not token:
         raise ValueError(
             "Missing token passed to headers utility! "

--- a/dataquality/utils/auth.py
+++ b/dataquality/utils/auth.py
@@ -1,7 +1,17 @@
+import os
+from time import time
 from typing import Dict, Optional
+
+import jwt
+
+from dataquality.core.auth import _Auth
 
 
 def headers(token: Optional[str]) -> Dict[str, str]:
+    """Return authorization headers for API requests
+    
+    If token is expired, attempt to refresh it.
+    """
     if not token:
         raise ValueError(
             "Missing token passed to headers utility! "
@@ -9,4 +19,5 @@ def headers(token: Optional[str]) -> Dict[str, str]:
             "dataquality.config.email. "
             "Your account email should appear."
         )
+
     return {"Authorization": f"Bearer {token}"}

--- a/dataquality/utils/auth.py
+++ b/dataquality/utils/auth.py
@@ -1,15 +1,9 @@
-import os
-from time import time
 from typing import Dict, Optional
-
-import jwt
-
-from dataquality.core.auth import _Auth
 
 
 def headers(token: Optional[str]) -> Dict[str, str]:
     """Return authorization headers for API requests
-    
+
     If token is expired, attempt to refresh it.
     """
     if not token:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "accelerate",
     "ipywidgets>=8.1.0",
     "imagededup>=0.3.1",
+    "pyjwt>=2.8.0",
 ]
 [[project.authors]]
 name = "Galileo Technologies, Inc."

--- a/tests/clients/test_api.py
+++ b/tests/clients/test_api.py
@@ -26,6 +26,18 @@ from tests.test_utils.mock_request import (
 api_client = ApiClient()
 
 
+@mock.patch.object(ApiClient, "_refresh_token")
+def test_refresh_token(
+    mock_refresh_token: MagicMock, set_test_config: Callable
+) -> None:
+    """Base case: Tests creating a new project and run"""
+    set_test_config(token="expired-token")
+    mock_refresh_token.return_value = "my-token"
+    token = api_client.get_token()
+    assert token == "my-token"
+    mock_refresh_token.assert_called_once()
+
+
 @mock.patch("requests.get", side_effect=mocked_get_project_run)
 @mock.patch("requests.delete", side_effect=mocked_delete_project_run)
 def test_delete_project(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,7 +144,7 @@ def disable_network_calls(request, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def valid_jwt_token(monkeypatch):
-    def decode_token(token: str = "my-token") -> Dict:
+    def decode_token(token: str) -> Dict:
         """Unless it's a mocked call to healthcheck, disable network access"""
         if "expired" in token:
             return {"exp": 0}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 import os
 import shutil
 import warnings
+from time import time
 from typing import Any, Callable, Dict, Generator, List, Optional, Union
 from uuid import UUID
 
+import jwt
 import pytest
 import requests
 import torch
@@ -138,6 +140,21 @@ def disable_network_calls(request, monkeypatch):
         raise RuntimeError("Network access not allowed during testing!")
 
     monkeypatch.setattr(requests, "get", lambda url, *args, **kwargs: stunted_get(url))
+
+
+@pytest.fixture(autouse=True)
+def valid_jwt_token(monkeypatch):
+    def decode_token(token: str = "my-token") -> Dict:
+        """Unless it's a mocked call to healthcheck, disable network access"""
+        if "expired" in token:
+            return {"exp": 0}
+
+        one_hour = 60 * 60
+        return {"exp": time() + one_hour}
+
+    monkeypatch.setattr(
+        jwt, "decode", lambda token, *args, **kwargs: decode_token(token)
+    )
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Shortcut Ticket
https://app.shortcut.com/galileo/story/10174/dq-api-client-token-refresh


## Drew Inspiration from
We should have an automatic token refresh similar to LLM Monitor and Prompt: https://github.com/rungalileo/llm-monitor/blob/1a42e5275dc5d4bb6b11219284269f44b02cab3b/llm_monitor/utils/api_client.py#L72-L89

## Testing
https://fmpm.dev/mocking-auth0-tokens


## Local example

My local token was expired but it used the local env to refresh succesfully.
```
>>> import os
>>> import jwt
>>> from time import time
>>> from dataquality.core._config import config

>>> os.environ["GALILEO_USERNAME"] = "<redacted>"
>>> os.environ["GALILEO_PASSWORD"] = "<redacted>"
>>> token = config.token
>>> exp = jwt.decode(token, options={"verify_signature": False})
>>> exp
{'sub': '<redacted>', 'id': '<redacted>', 'exp': 1700681062}
>>> time() > exp["exp"]
True

>>> ApiClient().get_current_user()
<response redacted>  # response succesful with refresh token
```