### PR TITLE
fix: ignore embs if not passed

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.3.9"
+__version__ = "1.3.10"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/core/log.py
+++ b/dataquality/core/log.py
@@ -385,10 +385,12 @@ def log_model_outputs(
     assert all(
         [config.task_type, config.current_project_id, config.current_run_id]
     ), "You must call dataquality.init before logging data"
+    remove_embs = False
     if config.task_type in TaskType.get_seq2seq_tasks():
         # Custom embeddings are optional in seq2seq
         if embs is None:
             exclude_embs = True
+            remove_embs = True
         if log_probs is not None:
             probs = log_probs
 
@@ -414,6 +416,7 @@ def log_model_outputs(
         probs=probs.astype(np.float32) if isinstance(probs, np.ndarray) else probs,
         inference_name=inference_name,
     )
+    model_logger.logger_config.remove_embs = remove_embs
     model_logger.log()
 
 

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -370,6 +370,9 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
             other_cols = [i for i in df_copy.get_column_names() if i not in ignore_cols]
             other_cols += ["id"]
 
+        if cls.logger_config.remove_embs:
+            emb_cols = ["id"]
+
         emb = df_copy[emb_cols]
         if "emb" in emb.get_column_names():
             # Convert emb to numpy array

--- a/dataquality/loggers/logger_config/base_logger_config.py
+++ b/dataquality/loggers/logger_config/base_logger_config.py
@@ -37,6 +37,7 @@ class BaseLoggerConfig(BaseModel):
     # True when calling `init` with a run that already exists
     existing_run: bool = False
     dataloader_random_sampling = False
+    remove_embs: bool = False
 
     class Config:
         validate_assignment = True


### PR DESCRIPTION
## Shortcut

https://app.shortcut.com/galileo/story/10245/dq-don-t-log-custom-embs-if-not-passed-in

We create random embs for other task types if they are not passed in. But for S2S we should just ignore (since no custom embs is permitted) 

Will fix these emb squares 
![Screen Shot 2023-12-14 at 6 31 54 PM](https://github.com/rungalileo/dataquality/assets/69087256/1c0e3786-018b-4fc9-bb48-0ad66ac32d9c)
