### PR TITLE
Fix misalignment between token offsets returned from the API and samples in the UI 

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/loggers/data_logger/seq2seq/formatters.py
+++ b/dataquality/loggers/data_logger/seq2seq/formatters.py
@@ -43,7 +43,7 @@ class BaseSeq2SeqDataFormatter(ABC):
         tokenizer: PreTrainedTokenizerFast,
         max_tokens: Optional[int],
         split_key: str,
-    ) -> Tuple[AlignedTokenData, List[List[str]]]:
+    ) -> Tuple[AlignedTokenData, List[List[str]], Optional[List[str]]]:
         """Tokenize and align the `text` samples
 
         `format_text` tokenizes and computes token alignments for
@@ -58,7 +58,12 @@ class BaseSeq2SeqDataFormatter(ABC):
         different between the two model architectures. See their respective
         implementations for further details.
 
-        Additionally, we assign the necessary `self.logger_config`.
+        Additional information computed / variable assignements:
+            - Assign the necessary `self.logger_config` fields
+            - Compute token_label_str: the per token str representation
+            of each sample (List[str]), saved and used for high DEP tokens.
+            - In Decoder-Only: Decode the response tokens to get the str
+            representation of the response (i.e. the target show in the UI).
 
         Parameters:
         -----------
@@ -78,6 +83,10 @@ class BaseSeq2SeqDataFormatter(ABC):
             Aligned token data for *just* target tokens, based on `text`
         token_label_str: List[List[str]]
             The target tokens (as strings) - see `Seq2SeqDataLogger.token_label_str`
+        label_strs: Optional[List[str]]
+            The decoded response tokens - i.e. the string representation of the
+            Targets for each sample. Note that this is only computed for
+            Decoder-Only models.
         """
         pass
 
@@ -212,7 +221,7 @@ class EncoderDecoderDataFormatter(BaseSeq2SeqDataFormatter):
         tokenizer: PreTrainedTokenizerFast,
         max_tokens: Optional[int],
         split_key: str,
-    ) -> Tuple[AlignedTokenData, List[List[str]]]:
+    ) -> Tuple[AlignedTokenData, List[List[str]], Optional[List[str]]]:
         """Further validation for Encoder-Decoder
 
         For Encoder-Decoder we need to:
@@ -257,7 +266,7 @@ class EncoderDecoderDataFormatter(BaseSeq2SeqDataFormatter):
         id_to_tokens = dict(zip(ids, token_label_ids))
         self.logger_config.id_to_tokens[split_key].update(id_to_tokens)
 
-        return batch_aligned_data, token_label_str
+        return batch_aligned_data, token_label_str, None
 
     @torch.no_grad()
     def generate_sample(
@@ -382,7 +391,7 @@ class DecoderOnlyDataFormatter(BaseSeq2SeqDataFormatter):
         tokenizer: PreTrainedTokenizerFast,
         max_tokens: Optional[int],
         split_key: str,
-    ) -> Tuple[AlignedTokenData, List[List[str]]]:
+    ) -> Tuple[AlignedTokenData, List[List[str]], List[str]]:
         """Further formatting for Decoder-Only
 
         Text is the formatted prompt of combined input/target
@@ -421,6 +430,8 @@ class DecoderOnlyDataFormatter(BaseSeq2SeqDataFormatter):
         # Empty initialization
         batch_aligned_data = AlignedTokenData([], [])
         token_label_str = []
+        str_labels = []
+
         # Decode then re-tokenize just the response labels to get correct offsets
         for token_label_ids in tqdm(
             tokenized_labels,
@@ -436,12 +447,16 @@ class DecoderOnlyDataFormatter(BaseSeq2SeqDataFormatter):
                 )
             )
 
-            response_aligned_data = align_response_tokens_to_character_spans(
+            (
+                response_aligned_data,
+                response_str,
+            ) = align_response_tokens_to_character_spans(
                 tokenizer,
                 token_label_ids,
                 max_input_tokens,
             )
             batch_aligned_data.append(response_aligned_data)
+            str_labels.append(response_str)
 
         # Save the tokenized response labels for each samples
         id_to_tokens = dict(zip(ids, tokenized_labels))
@@ -456,7 +471,7 @@ class DecoderOnlyDataFormatter(BaseSeq2SeqDataFormatter):
             id_to_formatted_prompt_length
         )
 
-        return batch_aligned_data, token_label_str
+        return batch_aligned_data, token_label_str, str_labels
 
     @torch.no_grad()
     def generate_sample(

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -118,14 +118,14 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         label_len = len(self.labels)
         text_len = len(self.texts)
         id_len = len(self.ids)
-        if label_len > 0:
+        if label_len > 0:  # Encoder-Decoder case
             assert id_len == text_len == label_len, (
                 "IDs, texts, and labels must be the same length, got "
                 f"({id_len} ids, {text_len} texts, {label_len} labels)"
             )
-        else:
+        else:  # Decoder-Only case
             assert id_len == text_len, (
-                "IDs and textsmust be the same length, got "
+                "IDs and texts must be the same length, got "
                 f"({id_len} ids, {text_len} texts)"
             )
         assert self.logger_config.tokenizer, (
@@ -150,7 +150,7 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         (
             batch_aligned_token_data,
             token_label_str,
-            labels,
+            targets,
         ) = self.formatter.format_text(
             text=texts,
             ids=self.ids,
@@ -161,8 +161,8 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         self.token_label_offsets = batch_aligned_token_data.token_label_offsets
         self.token_label_positions = batch_aligned_token_data.token_label_positions
         self.token_label_str = token_label_str
-        if labels is not None:
-            self.labels = labels
+        if len(targets) > 0:  # For Decoder-Only we update the 'targets' here
+            self.labels = targets
 
     def _get_input_df(self) -> DataFrame:
         df_dict = {

--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -118,10 +118,16 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         label_len = len(self.labels)
         text_len = len(self.texts)
         id_len = len(self.ids)
-        assert id_len == text_len == label_len, (
-            "IDs, texts, and labels must be the same length, got "
-            f"({id_len} ids, {text_len} texts, {label_len} labels)"
-        )
+        if label_len > 0:
+            assert id_len == text_len == label_len, (
+                "IDs, texts, and labels must be the same length, got "
+                f"({id_len} ids, {text_len} texts, {label_len} labels)"
+            )
+        else:
+            assert id_len == text_len, (
+                "IDs and textsmust be the same length, got "
+                f"({id_len} ids, {text_len} texts)"
+            )
         assert self.logger_config.tokenizer, (
             "You must set your tokenizer before logging. "
             "Use `dq.integrations.seq2seq.core.set_tokenizer`"
@@ -141,7 +147,11 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
             max_tokens = self.logger_config.max_target_tokens
         assert max_tokens
 
-        batch_aligned_token_data, token_label_str = self.formatter.format_text(
+        (
+            batch_aligned_token_data,
+            token_label_str,
+            labels,
+        ) = self.formatter.format_text(
             text=texts,
             ids=self.ids,
             tokenizer=self.logger_config.tokenizer,
@@ -151,6 +161,8 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         self.token_label_offsets = batch_aligned_token_data.token_label_offsets
         self.token_label_positions = batch_aligned_token_data.token_label_positions
         self.token_label_str = token_label_str
+        if labels is not None:
+            self.labels = labels
 
     def _get_input_df(self) -> DataFrame:
         df_dict = {

--- a/dataquality/utils/seq2seq/offsets.py
+++ b/dataquality/utils/seq2seq/offsets.py
@@ -274,7 +274,7 @@ def align_response_tokens_to_character_spans(
     tokenizer: PreTrainedTokenizerFast,
     tokenized_response: List[int],
     max_input_tokens: Optional[int],
-) -> AlignedTokenData:
+) -> Tuple[AlignedTokenData, str]:
     """Decodes then re-tokenizes the isolated response to get the character alignments
 
     TODO This can prob be done with just tokenizing the "target" in isolation!!
@@ -283,6 +283,15 @@ def align_response_tokens_to_character_spans(
         in the offset map and slice the offset map accordingly.
         This may also avoid strange space issues with tokenizers hanlding words
         at the start of a document.
+
+    Return:
+        -------
+        aligned_token_data: AlignedTokenData
+            Aligned token data for a single Response - batch dim = 1.
+        decoded_response: str
+            The string representation of the Response, used as the
+            Target string in the console. Note: we do not remove
+            special characters, so these will appear in the console!
     """
     decoded_response = tokenizer.decode(tokenized_response)
     re_tokenized_response = tokenizer(
@@ -293,6 +302,9 @@ def align_response_tokens_to_character_spans(
         # I believe that this should be handled! We can prob set to None
         max_length=max_input_tokens,
     )
-    return align_tokens_to_character_spans(
-        re_tokenized_response["offset_mapping"], disable_tqdm=True
+    return (
+        align_tokens_to_character_spans(
+            re_tokenized_response["offset_mapping"], disable_tqdm=True
+        ),
+        decoded_response,
     )


### PR DESCRIPTION
***Issue Description***

Right now, for Decoder-Only models, there is a small mis-alignment bug between what is processed by the DQ client and what we see in the UI. Essentially, there is a small disconnect (for many situations) between what the model "sees" (as input and returns alignment / token data on) and <Target> string that we display in the UI.

**Current Flow**
- User logs <Target> string column - this is what will be displayed in the UI and what we expect to compute aligned token info for. However, we cannot directly compute alignment / token info since decoder only models process the full <Input> + <Target> through what we call the `formatted_prompt`
- User logs `formatted_prompt`
  - Locate response template
  - Slice off all characters / tokens following the response template
  - These tokens (and their direct string representation) is what the model is seeing and what we use to compute **token alignment** and **token likelihoods**.

From this flow, we need the logged <Target> text and the *sliced response text* (from formatted_prompt) to EXACTLY match ---- But currently they don't always, for example in the case below:
```
response_template = "### response:"
target = "This is a test"
formatted_prompt = f"Input ### response: {target}"
...
sliced_response_text = " This is a test"
```
Where we see their is an added space in the `slice_response_text`. While subtle and honestly hard to see often in the UI, for certain cases this off by one case can really screw things up.

*** Solution ***
The proposed solution is to get rid of having the user log `labels` / `targets` and instead directly infer them from as the `sliced_response_text`. This way, there will be no discrepancy between what the model sees and what is in the UI!

This change works quite well with the current system design because for computing token alignmnet we already `decode` the response tokens in the function `align_response_tokens_to_character_spans`. 

Other benefits are:
- We get out of the box the ability to show the `EOS` token and other special tokens, which we have wanted to make the default anyways! NOTE this is just for Decoder-Only modles.
- The user no longer needs to log labels! Just `Inputs` and `Formatted Prompt` 

***Demonstration***

Example run with the error: [run](https://console.dev.rungalileo.io/insights/aa9f6d64-4a53-4801-94b6-5b48e3f452cf/d22a7332-c831-4c05-9c32-744f1cc7b4b9?groupedBy=galileo_formatted_prompts&taskType=8)

If you look at the token DEPs you can see that the highlighted tokens don't make sense / are clearly off by one. The tokenizer would never encoder `{"m` as one token. It really means to encode ` {"` but the space is missing!

Example run with the fix: [run](https://console.dev.rungalileo.io/insights/8b403041-42ea-4227-9bbd-47c87e7f818a/99242382-8407-4f21-bc58-8658efd4bdf9?dataframeColumns=bleu%3B%26data_error_potential%3B%26generated_output%3B%26generated_token_logprobs%3B%26generated_uncertainty%3B%26input%3B%26perplexity%3B%26rouge%3B%26target&groupedBy=galileo_formatted_prompts&taskType=8)

In the first sample you can see that ` {"` is properly tokenized! Also looking at the other samples you see that the space appears before tokens NOT after. This was another sign that in retrospect I should have seen with other runs but did not notice!
