### PR TITLE
feat: generation peft

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/integrations/seq2seq/core.py
+++ b/dataquality/integrations/seq2seq/core.py
@@ -172,8 +172,10 @@ def watch(
 
     # A model of the correct type is required if we need to generate
     if generation_splits:
-        assert isinstance(model, (PreTrainedModel, PeftModel))
+        assert isinstance(
+            model, (PreTrainedModel, PeftModel)
         ), "model must be an instance of transformers PreTrainedModel"
+
         assert (
             model.can_generate()
         ), "model must contain a `generate` method for seq2seq"

--- a/dataquality/integrations/seq2seq/core.py
+++ b/dataquality/integrations/seq2seq/core.py
@@ -172,8 +172,7 @@ def watch(
 
     # A model of the correct type is required if we need to generate
     if generation_splits:
-        assert isinstance(model, PreTrainedModel) or isinstance(
-            model, PeftModel
+        assert isinstance(model, (PreTrainedModel, PeftModel))
         ), "model must be an instance of transformers PreTrainedModel"
         assert (
             model.can_generate()

--- a/dataquality/integrations/seq2seq/core.py
+++ b/dataquality/integrations/seq2seq/core.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Union
 from warnings import warn
 
+from peft import PeftModel
 from tokenizers import Tokenizer
 from transformers import GenerationConfig, PreTrainedModel, PreTrainedTokenizerFast
 
@@ -171,8 +172,8 @@ def watch(
 
     # A model of the correct type is required if we need to generate
     if generation_splits:
-        assert isinstance(
-            model, PreTrainedModel
+        assert isinstance(model, PreTrainedModel) or isinstance(
+            model, PeftModel
         ), "model must be an instance of transformers PreTrainedModel"
         assert (
             model.can_generate()

--- a/dataquality/loggers/logger_config/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/logger_config/seq2seq/seq2seq_base.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Union
 
 from peft import PeftModel
 from transformers import GenerationConfig, PreTrainedModel, PreTrainedTokenizerFast
@@ -16,7 +16,7 @@ class Seq2SeqLoggerConfig(BaseLoggerConfig):
     max_target_tokens: Optional[int] = None
     # For each split/inference-name, store sample id -> List[token_id] for the label
     id_to_tokens: Dict[str, Dict[int, List[int]]] = defaultdict(dict)
-    model: Optional[Tuple[PreTrainedModel, PeftModel]] = None
+    model: Optional[Union[PreTrainedModel, PeftModel]] = None
     generation_config: Optional[GenerationConfig] = None
     generation_splits: Set[Split] = set()
     model_type: Optional[Seq2SeqModelType] = None

--- a/dataquality/loggers/logger_config/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/logger_config/seq2seq/seq2seq_base.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
+from peft import PeftModel
 from transformers import GenerationConfig, PreTrainedModel, PreTrainedTokenizerFast
 
 from dataquality.loggers.logger_config.base_logger_config import BaseLoggerConfig
@@ -15,7 +16,7 @@ class Seq2SeqLoggerConfig(BaseLoggerConfig):
     max_target_tokens: Optional[int] = None
     # For each split/inference-name, store sample id -> List[token_id] for the label
     id_to_tokens: Dict[str, Dict[int, List[int]]] = defaultdict(dict)
-    model: Optional[PreTrainedModel] = None
+    model: Optional[Tuple[PreTrainedModel, PeftModel]] = None
     generation_config: Optional[GenerationConfig] = None
     generation_splits: Set[Split] = set()
     model_type: Optional[Seq2SeqModelType] = None

--- a/dataquality/utils/seq2seq/generation.py
+++ b/dataquality/utils/seq2seq/generation.py
@@ -142,8 +142,14 @@ def add_generated_output_to_df(
         Updated Dataframe with the generated columns added (see above)
     """
     model.eval()
-    # During generation it is important to cache computation
-    # NOTE THAT WE SHOULD CHECK THAT THIS IS ALWAYS HERE!
+    # When generating it is important to set `use_cache = True`.
+    # - WHAT? Caching stores intermediate token activations / representations.
+    #   During autoregressive generation, the cache is updated each time a token
+    #   is generated.
+    # - WHY? Caching prevents re-computing token information during auto-regressive
+    #   generation, DRAMATICALLY speeding up performance. Every time a new token is
+    #   generated, we only need to do the forward pass for a single new token, as we
+    #   leverage the cached information to compute transformer based attention.
     model_cache_flag = model.config.use_cache
     model.config.use_cache = True
 

--- a/dataquality/utils/seq2seq/generation.py
+++ b/dataquality/utils/seq2seq/generation.py
@@ -142,6 +142,11 @@ def add_generated_output_to_df(
         Updated Dataframe with the generated columns added (see above)
     """
     model.eval()
+    # During generation it is important to cache computation
+    # NOTE THAT WE SHOULD CHECK THIS!
+    model_cache_flag = model.config.use_cache
+    model.config.use_cache = True
+
     generated_data = BatchGenerationData()
 
     num_batches = math.ceil(len(df) / GENERATION_BATCH_SIZE)
@@ -182,5 +187,8 @@ def add_generated_output_to_df(
     df[S2SOC.generated_top_logprobs.value] = pa.array(
         generated_data.generated_top_logprobs, type=TOP_LOGPROBS_SCHEMA
     )
+
+    # Reset the cache flag for the model
+    model.config.use_cache = model_cache_flag
 
     return df

--- a/dataquality/utils/seq2seq/generation.py
+++ b/dataquality/utils/seq2seq/generation.py
@@ -143,7 +143,7 @@ def add_generated_output_to_df(
     """
     model.eval()
     # During generation it is important to cache computation
-    # NOTE THAT WE SHOULD CHECK THIS!
+    # NOTE THAT WE SHOULD CHECK THAT THIS IS ALWAYS HERE!
     model_cache_flag = model.config.use_cache
     model.config.use_cache = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "ipywidgets>=8.1.0",
     "imagededup>=0.3.1",
     "pyjwt>=2.8.0",
+    "peft"
 ]
 [[project.authors]]
 name = "Galileo Technologies, Inc."


### PR DESCRIPTION
***What existing issue does this pull request close?***

Addresses two main issues:
1. Allowing for generation with `PEFTModels` from hf. This will be nearly the majority use case when people are fine-tuning very large models like Llama-2, since the general paradigm is to apply Parameter Efficient FT methods such as LORA and QLORA. Annoyingly a `PEFTModel`, while related to the hf library, comes from its own package `peft` and is not a subclass of a `PreTrainedModel`.
2. When generating, setting `model.config.use_cache=True` is very important for speed purposes. Otherwise generation is prohibitively slow! 