### PR TITLE
fix: logged in as none and reprocess finetune fixes

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -31,7 +31,7 @@ If you want to train without a model, you can use the auto framework:
 """
 
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 import sys
 from typing import Any, List, Optional

--- a/dataquality/core/auth.py
+++ b/dataquality/core/auth.py
@@ -53,8 +53,10 @@ def login() -> None:
     print(f"📡 {config.api_url.replace('api','console')}")
     print("🔭 Logging you into Galileo\n")
 
+    _auth = _Auth()
+    if os.getenv("GALILEO_USERNAME") and os.getenv("GALILEO_PASSWORD"):
+        _auth.login_with_env_vars()
     if not valid_current_user:
-        _auth = _Auth()
         _auth.login_with_token()
 
     current_user_email = api_client.get_current_user().get("email")

--- a/dataquality/core/auth.py
+++ b/dataquality/core/auth.py
@@ -49,27 +49,23 @@ def login() -> None:
         config.token = None
         config.update_file_config()
 
-    if api_client.valid_current_user():
-        print(f"✅ Already logged in as {config.current_user}!")
-        print("Use logout() if you want to change users")
-
-        return
-
+    valid_current_user = api_client.valid_current_user()
     print(f"📡 {config.api_url.replace('api','console')}")
     print("🔭 Logging you into Galileo\n")
 
-    _auth = _Auth()
-    if os.getenv("GALILEO_USERNAME") and os.getenv("GALILEO_PASSWORD"):
-        _auth.login_with_env_vars()
-    else:
+    if not valid_current_user:
+        _auth = _Auth()
         _auth.login_with_token()
 
     current_user_email = api_client.get_current_user().get("email")
     if not current_user_email:
         return
+
     config.current_user = current_user_email
     config.update_file_config()
+
     print(f"🚀 You're logged in to Galileo as {current_user_email}!")
+    print("Use logout() if you want to change users")
 
 
 @check_noop

--- a/dataquality/internal.py
+++ b/dataquality/internal.py
@@ -41,7 +41,8 @@ def reprocess_run(
         api_client.delete_alerts(project_name, run_name)
 
     job_data: Dict = job["request_data"]
-    # We need to remove the job_id from the job_data, otherwise the server will
+    # We need to remove the job_id from the job_data since the server will
+    # generate a new one
     job_data.pop("job_id")
     res = api_client.make_request(
         RequestType.POST, url=f"{config.api_url}/{Route.jobs}", body=job_data

--- a/dataquality/internal.py
+++ b/dataquality/internal.py
@@ -29,10 +29,12 @@ def reprocess_run(
     project, run = api_client._get_project_run_id(project_name, run_name)
     task_type = api_client.get_task_type(project, run)
 
+    labels = []
     tasks = []
     ner_labels = []
     try:
-        labels = api_client.get_labels_for_run(project_name, run_name)
+        if task_type in TaskType.get_label_tasks():
+            labels = api_client.get_labels_for_run(project_name, run_name)
     except GalileoException as e:
         if "No data found" in str(e):
             e = GalileoException(
@@ -55,6 +57,7 @@ def reprocess_run(
         ner_labels = dataquality.metrics.get_labels_for_run(project_name, run_name)
     if alerts:
         api_client.delete_alerts(project_name, run_name)
+
     body = dict(
         project_id=str(project),
         run_id=str(run),

--- a/dataquality/internal.py
+++ b/dataquality/internal.py
@@ -1,10 +1,10 @@
 """Internal functions to help Galileans"""
-import dataquality.metrics
+from typing import Dict
+
 from dataquality import config
 from dataquality.clients.api import ApiClient
 from dataquality.exceptions import GalileoException
 from dataquality.schemas import RequestType, Route
-from dataquality.schemas.task_type import TaskType
 
 api_client = ApiClient()
 
@@ -27,55 +27,24 @@ def reprocess_run(
         fire and forget your process. Default True
     """
     project, run = api_client._get_project_run_id(project_name, run_name)
-    task_type = api_client.get_task_type(project, run)
+    api_client.get_task_type(project, run)
 
-    labels = []
-    tasks = []
-    ner_labels = []
-    try:
-        if task_type in TaskType.get_label_tasks():
-            labels = api_client.get_labels_for_run(project_name, run_name)
-    except GalileoException as e:
-        if "No data found" in str(e):
-            e = GalileoException(
-                f"It seems no data is available for run " f"{project_name}/{run_name}"
-            )
-        raise e from None
-    # There were no labels available for this run
-    except KeyError:
+    job = api_client.get_run_status(project_name, run_name)
+    if not job:
         raise GalileoException(
-            "It seems we cannot find the labels for this run. This means "
+            "It seems we cannot find the job for this run. This means "
             "that the run cannot be reprocessed, because it likely was never processed "
             "to begin with. Please call dq.init() and re-train your model "
         ) from None
-    # Multi-label has tasks and List[List] for labels
-    if task_type == TaskType.text_multi_label:
-        tasks = api_client.get_tasks_for_run(project_name, run_name)
-    if task_type == TaskType.text_ner:
-        # In NER, dq.metrics.get_labels_for_run will return the _full_ label set in NER
-        # form (ie B-PER, I-PER, O-PER, B-LOC, etc) which is needed for processing
-        ner_labels = dataquality.metrics.get_labels_for_run(project_name, run_name)
+
     if alerts:
         api_client.delete_alerts(project_name, run_name)
 
-    body = dict(
-        project_id=str(project),
-        run_id=str(run),
-        labels=labels,
-        tasks=tasks or None,
-        task_type=task_type,
-        ner_labels=ner_labels,
-        xray=alerts,
-        # We set the job name to inference and non_inference_logged to True because
-        # This will force the server to first reprocess the non-inference splits,
-        # and then reprocess all of the inference splits. If there are no inference
-        # splits, this will still work as expected, inference will just be skipped
-        job_name="inference",
-        process_existing_inference_runs=True,
-        non_inference_logged=True,
-    )
+    job_data: Dict = job["request_data"]
+    # We need to remove the job_id from the job_data, otherwise the server will
+    job_data.pop("job_id")
     res = api_client.make_request(
-        RequestType.POST, url=f"{config.api_url}/{Route.jobs}", body=body
+        RequestType.POST, url=f"{config.api_url}/{Route.jobs}", body=job_data
     )
     print(
         f"Job {res['job_name']} successfully resubmitted. New results will be "

--- a/dataquality/schemas/task_type.py
+++ b/dataquality/schemas/task_type.py
@@ -29,6 +29,18 @@ class TaskType(str, Enum):
         ]
 
     @staticmethod
+    def get_label_tasks() -> List["TaskType"]:
+        """Tasks types that require a labels.json file."""
+        return [
+            TaskType.text_classification,
+            TaskType.text_multi_label,
+            TaskType.text_ner,
+            TaskType.image_classification,
+            TaskType.tabular_classification,
+            TaskType.object_detection,
+        ]
+
+    @staticmethod
     def get_seq2seq_tasks() -> List["TaskType"]:
         """Sequence to Sequence tasks types."""
         return [

--- a/dataquality/schemas/task_type.py
+++ b/dataquality/schemas/task_type.py
@@ -29,18 +29,6 @@ class TaskType(str, Enum):
         ]
 
     @staticmethod
-    def get_label_tasks() -> List["TaskType"]:
-        """Tasks types that require a labels.json file."""
-        return [
-            TaskType.text_classification,
-            TaskType.text_multi_label,
-            TaskType.text_ner,
-            TaskType.image_classification,
-            TaskType.tabular_classification,
-            TaskType.object_detection,
-        ]
-
-    @staticmethod
     def get_seq2seq_tasks() -> List["TaskType"]:
         """Sequence to Sequence tasks types."""
         return [

--- a/tests/integrations/setfit/test_setfit.py
+++ b/tests/integrations/setfit/test_setfit.py
@@ -1,3 +1,4 @@
+import os
 from typing import Callable, Generator
 from unittest.mock import MagicMock, patch
 
@@ -197,7 +198,6 @@ def test_setfit_trainer(
     dq.finish()
 
 
-@patch.object(ApiClient, "valid_current_user", return_value=True)
 @patch.object(dq.core.init, "version_check")
 @patch.object(dq.core.finish, "_reset_run")
 @patch.object(dq.core.finish, "upload_dq_log_file")
@@ -220,26 +220,26 @@ def test_setfit_trainer(
         "minio_fqdn": "127.0.0.1:9000",
     },
 )
+@patch.object(ApiClient, "get_current_user", return_value={"email": "hi@example.com"})
 @patch.object(dq.core.init.ApiClient, "valid_current_user", return_value=True)
 def test_auto(
     mock_valid_user: MagicMock,
+    mock_get_current_user: MagicMock,
     mock_dq_healthcheck: MagicMock,
     mock_check_dq_version: MagicMock,
     mock_create_run: MagicMock,
     mock_get_project_run_by_name: MagicMock,
     mock_create_project: MagicMock,
     mock_get_project_by_name: MagicMock,
-    set_test_config: Callable,
     mock_wait_for_run: MagicMock,
     mock_make_request: MagicMock,
     mock_upload_log_file: MagicMock,
     mock_reset_run: MagicMock,
     mock_version_check: MagicMock,
+    set_test_config: Callable,
     cleanup_after_use: Generator,
     test_session_vars: TestSessionVariables,
 ) -> None:
-    import os
-
     mock_get_project_by_name.return_value = {"id": test_session_vars.DEFAULT_PROJECT_ID}
     mock_create_run.return_value = {"id": test_session_vars.DEFAULT_RUN_ID}
     set_test_config(current_project_id=None, current_run_id=None)

--- a/tests/start/test_start_auto.py
+++ b/tests/start/test_start_auto.py
@@ -10,7 +10,6 @@ from dataquality.clients.api import ApiClient
 from tests.conftest import LOCAL_MODEL_PATH, TestSessionVariables
 
 
-@patch.object(dq.core.init.ApiClient, "valid_current_user", return_value=True)
 @patch.object(dq.core.init, "version_check")
 @patch.object(dq.core.finish, "_reset_run")
 @patch.object(dq.core.finish, "upload_dq_log_file")
@@ -33,21 +32,23 @@ from tests.conftest import LOCAL_MODEL_PATH, TestSessionVariables
         "minio_fqdn": "127.0.0.1:9000",
     },
 )
+@patch.object(ApiClient, "get_current_user", return_value={"email": "hi@example.com"})
 @patch.object(dq.core.init.ApiClient, "valid_current_user", return_value=True)
 def test_auto(
     mock_valid_user: MagicMock,
+    mock_get_current_user: MagicMock,
     mock_bucket_names: MagicMock,
     mock_check_dq_version: MagicMock,
     mock_create_run: MagicMock,
     mock_get_project_run_by_name: MagicMock,
     mock_create_project: MagicMock,
     mock_get_project_by_name: MagicMock,
-    set_test_config: Callable,
     mock_wait_for_run: MagicMock,
     mock_make_request: MagicMock,
     mock_upload_log_file: MagicMock,
     mock_reset_run: MagicMock,
     mock_version_check: MagicMock,
+    set_test_config: Callable,
     cleanup_after_use: Generator,
     test_session_vars: TestSessionVariables,
 ) -> None:


### PR DESCRIPTION
## Shortcut

https://app.shortcut.com/galileo/story/11305/dq-logged-in-as-none?vc_group_by=day&ct_workflow=all&cf_workflow=500000005

https://app.shortcut.com/galileo/story/11306/dq-reprocess-broken-for-finetune?vc_group_by=day&ct_workflow=all&cf_workflow=500000005


Tested login wiht a few flows and was able to reproduce and fix:
```
>>> dq.login()
📡 https://console.dev.rungalileo.io
🔭 Logging you into Galileo

🚀 You're logged in to Galileo as galileo@rungalileo.io!
Use logout() if you want to change users
```


Tested reprocess locally and it worked like a charm 
```
>>> reprocess_run("Seq2Seq_DecoderOnly_Log_Logprobs", "2023-11-13_9")
All alerts removed for run Seq2Seq_DecoderOnly_Log_Logprobs/2023-11-13_9
Job default successfully resubmitted. New results will be available soon at https://console.dev.rungalileo.io/insights/4551e611-011a-4004-a8ba-b3113980f2ca/2f2fdd25-68ae-4be0-be94-ef62590a7345?split=training&taskType=8
Waiting for job (you can safely close this window)...
        Downloading all embedding files for this run
        [training] 👀 Looking for data anomalies
Done! Job finished with status completed
{'project_id': '4551e611-011a-4004-a8ba-b3113980f2ca', 'run_id': '2f2fdd25-68ae-4be0-be94-ef62590a7345', 'job_id': '548062a2-0abd-4dc9-bffa-87b20ae7ac85', 'job_name': 'default', 'task_type': 8, 'labels': [], 'ner_labels': [], 'tasks': None, 'non_inference_logged': False, 'migration_name': None, 'xray': True, 'process_existing_inference_runs': False, 'feature_names': [], 'prompt_dataset_id': None, 'prompt_template_version_id': None, 'monitor_batch_id': None, 'prompt_settings': None, 'prompt_scorers_configuration': None, 'prompt_registered_scorers_configuration': None, 'prompt_scorer_settings': None, 'message': 'Processing job!', 'link': '/insights/4551e611-011a-4004-a8ba-b3113980f2ca/2f2fdd25-68ae-4be0-be94-ef62590a7345?split=training&taskType=8'}
```