### PR TITLE
fix(seq2seq): Include action info in data logger errors

### DIFF
--- a/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
+++ b/dataquality/loggers/data_logger/seq2seq/seq2seq_base.py
@@ -191,6 +191,14 @@ class Seq2SeqDataLogger(BaseGalileoDataLogger):
         meta: Union[List[str], List[int], None] = None,
     ) -> None:
         """Helper to log a pandas or vaex df"""
+        assert S2SIC.input in df, (
+            f"Input column {S2SIC.input} not found in dataframe. "
+            f"Please add a column titled {S2SIC.input} to your dataframe "
+        )
+        assert S2SIC.id in df, (
+            f"ID column {S2SIC.id} not found in dataframe. "
+            f"Please add a column titled {S2SIC.id} to your dataframe "
+        )
         self.texts = df[S2SIC.input].tolist()
         self.ids = df[S2SIC.id].tolist()
         # Inference case


### PR DESCRIPTION
Changed to make the errors more explicit as I ran into some trouble while using the data logger.