### PR TITLE
fix: re-add og internal reprocess fn

### DIFF
--- a/dataquality/__init__.py
+++ b/dataquality/__init__.py
@@ -30,7 +30,6 @@ If you want to train without a model, you can use the auto framework:
         dataquality.get_insights()
 """
 
-
 __version__ = "1.6.0"
 
 import sys

--- a/dataquality/integrations/setfit.py
+++ b/dataquality/integrations/setfit.py
@@ -353,7 +353,7 @@ def do_model_eval(
             dq_evaluate(
                 encoded_data[split],
                 split=split,
-                meta=meta_columns
+                meta=meta_columns,
                 # for inference set the split to inference
                 # and pass an inference_name="inference_run_1"
             )

--- a/dataquality/integrations/torch.py
+++ b/dataquality/integrations/torch.py
@@ -296,10 +296,10 @@ def watch(
 def unwatch(model: Optional[Module] = None, force: bool = True) -> None:
     """Unwatches the model. Run after the run is finished.
     :param force: Force unwatch even if the model is not watched"""
-    torch_helper_data: TorchHelper = (
-        dq.get_model_logger().logger_config.helper_data.get(
-            "torch_helper", TorchHelper()
-        )
+    torch_helper_data: (
+        TorchHelper
+    ) = dq.get_model_logger().logger_config.helper_data.get(
+        "torch_helper", TorchHelper()
     )
 
     model = model or torch_helper_data.model

--- a/dataquality/integrations/ultralytics.py
+++ b/dataquality/integrations/ultralytics.py
@@ -234,8 +234,8 @@ class Callback:
             logging_data = process_batch_data(self.bl.batch)
             if not self.nms_fn:
                 raise Exception("NMS function not found")
-            postprocess = (
-                lambda x: x if self.split == Split.validation else self.postprocess
+            postprocess = lambda x: (
+                x if self.split == Split.validation else self.postprocess
             )
             preds = postprocess(preds)
             nms = self.nms_fn(

--- a/dataquality/internal.py
+++ b/dataquality/internal.py
@@ -1,4 +1,5 @@
 """Internal functions to help Galileans"""
+
 from typing import Dict
 
 import dataquality

--- a/dataquality/internal.py
+++ b/dataquality/internal.py
@@ -1,10 +1,12 @@
 """Internal functions to help Galileans"""
 from typing import Dict
 
+import dataquality
 from dataquality import config
 from dataquality.clients.api import ApiClient
 from dataquality.exceptions import GalileoException
 from dataquality.schemas import RequestType, Route
+from dataquality.schemas.task_type import TaskType
 
 api_client = ApiClient()
 
@@ -46,6 +48,80 @@ def reprocess_run(
     job_data.pop("job_id")
     res = api_client.make_request(
         RequestType.POST, url=f"{config.api_url}/{Route.jobs}", body=job_data
+    )
+    print(
+        f"Job {res['job_name']} successfully resubmitted. New results will be "
+        f"available soon at {res['link']}"
+    )
+    if wait:
+        api_client.wait_for_run(project_name, run_name)
+    return res
+
+
+def reprocess_transferred_run(
+    project_name: str, run_name: str, alerts: bool = True, wait: bool = True
+) -> None:
+    """Reprocess a run that has been transferred from another cluster
+
+    This is an internal helper function that allows us to reprocess a run that has been
+    transferred from another cluster.
+
+    :param project_name: The name of the project
+    :param run_name: The name of the run
+    :param alerts: Whether to create the alerts. If True, all alerts for the run will
+        be removed, and recreated during processing. Default True
+    :param wait: Whether to wait for the run to complete processing on the server. If
+        True, this will block execution, printing out the status updates of the run.
+        Useful if you want to know exactly when your run completes. Otherwise, this will
+        fire and forget your process. Default True
+    """
+    project, run = api_client._get_project_run_id(project_name, run_name)
+    task_type = api_client.get_task_type(project, run)
+
+    tasks = []
+    ner_labels = []
+    try:
+        labels = api_client.get_labels_for_run(project_name, run_name)
+    except GalileoException as e:
+        if "No data found" in str(e):
+            e = GalileoException(
+                f"It seems no data is available for run " f"{project_name}/{run_name}"
+            )
+        raise e from None
+    # There were no labels available for this run
+    except KeyError:
+        raise GalileoException(
+            "It seems we cannot find the labels for this run. This means "
+            "that the run cannot be reprocessed, because it likely was never processed "
+            "to begin with. Please call dq.init() and re-train your model "
+        ) from None
+    # Multi-label has tasks and List[List] for labels
+    if task_type == TaskType.text_multi_label:
+        tasks = api_client.get_tasks_for_run(project_name, run_name)
+    if task_type == TaskType.text_ner:
+        # In NER, dq.metrics.get_labels_for_run will return the _full_ label set in NER
+        # form (ie B-PER, I-PER, O-PER, B-LOC, etc) which is needed for processing
+        ner_labels = dataquality.metrics.get_labels_for_run(project_name, run_name)
+    if alerts:
+        api_client.delete_alerts(project_name, run_name)
+    body = dict(
+        project_id=str(project),
+        run_id=str(run),
+        labels=labels,
+        tasks=tasks or None,
+        task_type=task_type,
+        ner_labels=ner_labels,
+        xray=alerts,
+        # We set the job name to inference and non_inference_logged to True because
+        # This will force the server to first reprocess the non-inference splits,
+        # and then reprocess all of the inference splits. If there are no inference
+        # splits, this will still work as expected, inference will just be skipped
+        job_name="inference",
+        process_existing_inference_runs=True,
+        non_inference_logged=True,
+    )
+    res = api_client.make_request(
+        RequestType.POST, url=f"{config.api_url}/{Route.jobs}", body=body
     )
     print(
         f"Job {res['job_name']} successfully resubmitted. New results will be "

--- a/dataquality/loggers/base_logger.py
+++ b/dataquality/loggers/base_logger.py
@@ -208,8 +208,7 @@ class BaseGalileoLogger:
         )
 
     @abstractmethod
-    def log(self) -> None:
-        ...
+    def log(self) -> None: ...
 
     @staticmethod
     def _convert_tensor_ndarray(
@@ -327,8 +326,7 @@ class BaseGalileoLogger:
         pm = PatchManager()
         pm.unpatch()
 
-    def upload(self) -> None:
-        ...
+    def upload(self) -> None: ...
 
     @classmethod
     def get_all_subclasses(cls: Type[T]) -> List[Type[T]]:

--- a/dataquality/loggers/base_logger.py
+++ b/dataquality/loggers/base_logger.py
@@ -208,7 +208,8 @@ class BaseGalileoLogger:
         )
 
     @abstractmethod
-    def log(self) -> None: ...
+    def log(self) -> None:
+        ...
 
     @staticmethod
     def _convert_tensor_ndarray(
@@ -326,7 +327,8 @@ class BaseGalileoLogger:
         pm = PatchManager()
         pm.unpatch()
 
-    def upload(self) -> None: ...
+    def upload(self) -> None:
+        ...
 
     @classmethod
     def get_all_subclasses(cls: Type[T]) -> List[Type[T]]:

--- a/dataquality/loggers/data_logger/base_data_logger.py
+++ b/dataquality/loggers/data_logger/base_data_logger.py
@@ -578,7 +578,8 @@ class BaseGalileoDataLogger(BaseGalileoLogger):
 
     @classmethod
     @abstractmethod
-    def validate_labels(cls) -> None: ...
+    def validate_labels(cls) -> None:
+        ...
 
     def validate_metadata(self, batch_size: int) -> None:
         if len(self.meta.keys()) > self.MAX_META_COLS:
@@ -688,7 +689,8 @@ class BaseGalileoDataLogger(BaseGalileoLogger):
     @abstractmethod
     def separate_dataframe(
         cls, df: DataFrame, prob_only: bool = False, split: Optional[str] = None
-    ) -> BaseLoggerDataFrames: ...
+    ) -> BaseLoggerDataFrames:
+        ...
 
     def validate_kwargs(self, kwargs: Dict) -> None:
         """Raises if a function that shouldn't get kwargs gets any"""
@@ -696,7 +698,8 @@ class BaseGalileoDataLogger(BaseGalileoLogger):
             raise GalileoException(f"Unexpected arguments: {tuple(kwargs.keys())}")
 
     @abstractmethod
-    def _get_input_df(self) -> DataFrame: ...
+    def _get_input_df(self) -> DataFrame:
+        ...
 
     @classmethod
     def set_tagging_schema(cls, tagging_schema: TaggingSchema) -> None:

--- a/dataquality/loggers/data_logger/base_data_logger.py
+++ b/dataquality/loggers/data_logger/base_data_logger.py
@@ -578,8 +578,7 @@ class BaseGalileoDataLogger(BaseGalileoLogger):
 
     @classmethod
     @abstractmethod
-    def validate_labels(cls) -> None:
-        ...
+    def validate_labels(cls) -> None: ...
 
     def validate_metadata(self, batch_size: int) -> None:
         if len(self.meta.keys()) > self.MAX_META_COLS:
@@ -689,8 +688,7 @@ class BaseGalileoDataLogger(BaseGalileoLogger):
     @abstractmethod
     def separate_dataframe(
         cls, df: DataFrame, prob_only: bool = False, split: Optional[str] = None
-    ) -> BaseLoggerDataFrames:
-        ...
+    ) -> BaseLoggerDataFrames: ...
 
     def validate_kwargs(self, kwargs: Dict) -> None:
         """Raises if a function that shouldn't get kwargs gets any"""
@@ -698,8 +696,7 @@ class BaseGalileoDataLogger(BaseGalileoLogger):
             raise GalileoException(f"Unexpected arguments: {tuple(kwargs.keys())}")
 
     @abstractmethod
-    def _get_input_df(self) -> DataFrame:
-        ...
+    def _get_input_df(self) -> DataFrame: ...
 
     @classmethod
     def set_tagging_schema(cls, tagging_schema: TaggingSchema) -> None:

--- a/tests/integrations/setfit/test_setfit.py
+++ b/tests/integrations/setfit/test_setfit.py
@@ -191,7 +191,7 @@ def test_setfit_trainer(
     dq_evaluate(
         dataset,
         split="test",
-        column_mapping=column_mapping
+        column_mapping=column_mapping,
         # for inference set the split to inference
         # and pass an inference_name="inference_run_1"
     )

--- a/tests/loggers/test_seq2seq.py
+++ b/tests/loggers/test_seq2seq.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import Callable, Generator
 from unittest.mock import MagicMock, Mock, patch
 
@@ -646,7 +647,7 @@ def test_create_data_embs_df_custom_column(
 
     # Check that no exception is thrown and that data embs are created
     assert "text" not in df.get_column_names()
-    with pytest.warns(None):
+    with warnings.catch_warnings(record=True):
         data_embs = create_data_embs_df(df, text_col="other")
 
     assert len(data_embs) == 2

--- a/tests/test_telemetrics.py
+++ b/tests/test_telemetrics.py
@@ -6,7 +6,6 @@ import pytest
 
 from dataquality import config
 from dataquality.analytics import Analytics
-from dataquality.clients.api import ApiClient
 
 os.environ["DQ_DEBUG"] = "1"
 

--- a/tests/test_telemetrics.py
+++ b/tests/test_telemetrics.py
@@ -1,5 +1,6 @@
 import os
 from typing import Dict
+from uuid import uuid4
 
 import pytest
 
@@ -23,14 +24,16 @@ class MockClient:
 
 
 def test_mock_log_galileo_import():
-    a = Analytics(MockClient, {"api_url": "https://console.dev.rungalileo.io"})
+    os.environ["DQ_TELEMETRICS"] = "1"
+    a = Analytics(MockClient, config)
     a.last_log = {}
     a.log_import("test")
     assert a.last_log["value"] == "test", "No import detected"
 
 
 def test_log_galileo_exception():
-    a = Analytics(MockClient, {"api_url": "https://console.dev.rungalileo.io"})
+    os.environ["DQ_TELEMETRICS"] = "1"
+    a = Analytics(MockClient, config)
     assert a._initialized, "Analytics not initialized"
     try:
         10 / 0
@@ -43,12 +46,13 @@ def test_log_galileo_exception():
 
 
 def test_log_galileo__import():
-    ac = Analytics(ApiClient, config)
+    os.environ["DQ_TELEMETRICS"] = "1"
+    ac = Analytics(MockClient, config)
     config.api_url = "https://console.dev.rungalileo.io"
     ac.last_log = {}
     # Only check if telemetrics is enabled.
     if not ac._telemetrics_disabled:
-        ac.config["current_project_id"] = "test"
+        ac.config.current_project_id = uuid4()
         assert ac._initialized, "Analytics not initialized"
         ac._telemetrics_disabled = False
         ac.log_import("test")
@@ -56,6 +60,7 @@ def test_log_galileo__import():
 
 
 def test_mock_log_galileo_import_disabled():
+    os.environ["DQ_TELEMETRICS"] = "0"
     a_telemetrics_disabled = Analytics(MockClient, {"api_url": "https://customer"})
     a_telemetrics_disabled.last_log = {}
     a_telemetrics_disabled.log_import("test")


### PR DESCRIPTION
Re-introducing the old reprocess run logic since it was useful for transferred runs that don't have a preexisting job 