### PR TITLE
ci(docs): Disable running with `workflow_dispatch` since this is a public repo

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,7 +1,6 @@
 name: Publish Docs
 
 on:
-  workflow_dispatch:
   workflow_run:
     workflows: ["publish"]
     types:


### PR DESCRIPTION
**Description:** `workflow_dispatch` is a terrible idea when in a public repo.

I had added it so that I could debug in case the run after #832 failed. It didn't so we can remove it.