### PR TITLE
ci(docs): Install `poetry` in setup step

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Dependencies
         # Install all dependencies so that the docs can use the function and type signatures.
         run: |
-          pipx install invoke
+          pipx install invoke poetry=="1.7.0"
           invoke install
 
       - name: Build Docs


### PR DESCRIPTION
[CI for docs failed](https://github.com/rungalileo/dataquality/actions/runs/8116632585/job/22187091557) after #833 because of missing this.