### PR TITLE
ci: Fix pre-commit and stale workflows to remove mixup

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,21 +1,16 @@
-name: "Close Stale"
+name: "Style Check"
+
 on:
-  workflow_call:
-  schedule:
-    - cron: "30 1 * * *"
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
-  stale:
+  pre-commit:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
+    env:
+      SKIP: "mypy"
     steps:
-      - uses: actions/stale@v9
-        with:
-          stale-issue-message: "This issue has been identified as stale. Please leave a comment if it's still current or it'll be closed."
-          stale-pr-message: "This pull request has been identified as stale. Please leave a comment if it's still current or it'll be closed."
-          days-before-issue-stale: 30
-          days-before-pr-stale: 30
-          days-before-issue-close: 5
-          days-before-pr-close: 5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,8 +1,21 @@
 name: "Close Stale"
 on:
+  workflow_call:
   schedule:
     - cron: "30 1 * * *"
 
 jobs:
-  pre-commit:
-    uses: rungalileo/.github/.github/workflows/stale.yaml@main
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: "This issue has been identified as stale. Please leave a comment if it's still current or it'll be closed."
+          stale-pr-message: "This pull request has been identified as stale. Please leave a comment if it's still current or it'll be closed."
+          days-before-issue-stale: 30
+          days-before-pr-stale: 30
+          days-before-issue-close: 5
+          days-before-pr-close: 5

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,6 +1,5 @@
 name: "Close Stale"
 on:
-  workflow_call:
   schedule:
     - cron: "30 1 * * *"
 


### PR DESCRIPTION
**Description:** In my attempt to remove the dependence on internal workflows in #838, I mixed up and made changes to the workflow from #837. This should bring them back into alignment as we expect them to be.

Oops!