### PR TITLE
ci: Install root package in docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -25,6 +25,7 @@ jobs:
         run: |
           pipx install invoke poetry=="1.7.0"
           invoke install
+          poetry install --only-root
 
       - name: Build Docs
         run: invoke docs-build


### PR DESCRIPTION
The action [for docs failed](https://github.com/rungalileo/dataquality/actions/runs/8163197346/job/22315882912) after v2.0.1 so fixing that.