### PR TITLE
ci: Install the `docs` extras when building docs

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -24,8 +24,7 @@ jobs:
         # Install all dependencies so that the docs can use the function and type signatures.
         run: |
           pipx install invoke poetry=="1.7.0"
-          invoke install
-          poetry install --only-root
+          poetry install --extras minio --extras setfit --with test,dev,docs
 
       - name: Build Docs
         run: invoke docs-build


### PR DESCRIPTION
The install was still missing a couple things.

I just ran this E2E locally now so everything should work fine next release onwards.