### PR TITLE
feat(model_upload): Add tokenizer to upload_model_to_dq function

### DIFF
--- a/dataquality/core/finish.py
+++ b/dataquality/core/finish.py
@@ -97,7 +97,8 @@ def finish(
                 model = helper_data["model"]
                 model_parameters = helper_data["model_parameters"]
                 model_kind = helper_data["model_kind"]
-                upload_model_to_dq(model, model_parameters, model_kind)
+                tokenizer = helper_data["tokenizer"]
+                upload_model_to_dq(model, model_parameters, model_kind, tokenizer)
                 print("Model uploaded successfully.")
             else:
                 print("No model to upload.")

--- a/dataquality/integrations/transformers_trainer.py
+++ b/dataquality/integrations/transformers_trainer.py
@@ -339,6 +339,7 @@ def watch(
     cleanup_manager = RefManager(lambda: unwatch(trainer))
     helper_data["cleaner"] = Cleanup(cleanup_manager)
     helper_data["model"] = trainer.model
+    helper_data["tokenizer"] = trainer.tokenizer
     helper_data["model_parameters"] = {
         "classifier_layer": classifier_layer,
         "embedding_dim": embedding_dim,

--- a/dataquality/utils/upload_model.py
+++ b/dataquality/utils/upload_model.py
@@ -4,6 +4,7 @@ import tempfile
 from typing import Any, Dict, Tuple
 
 import requests
+from transformers import PreTrainedTokenizer
 
 from dataquality.clients.api import ApiClient
 from dataquality.core._config import config
@@ -34,7 +35,10 @@ def upload_to_minio_using_presigned_url(presigned_url: str, file_path: str) -> T
 
 
 def upload_model_to_dq(
-    model: Any, model_parameters: Dict[str, Any], model_kind: ModelUploadType
+    model: Any,
+    model_parameters: Dict[str, Any],
+    model_kind: ModelUploadType,
+    tokenizer: PreTrainedTokenizer,
 ) -> None:
     """
     Uploads the model to the Galileo platform.
@@ -52,6 +56,7 @@ def upload_model_to_dq(
     # save to temporary folder
     with tempfile.TemporaryDirectory() as tmpdirname:
         model.save_pretrained(f"{tmpdirname}/model_export")
+        tokenizer.save_pretrained(f"{tmpdirname}/model_export")
         tar_path = f"{tmpdirname}/model.tar.gz"
         create_tar_archive(f"{tmpdirname}/model_export", tar_path)
         upload_to_minio_using_presigned_url(signed_url, tar_path)

--- a/tests/core/test_finish.py
+++ b/tests/core/test_finish.py
@@ -190,6 +190,7 @@ def test_finish_dq_upload(
     )
     helper_data = dataquality.core.log.get_model_logger().logger_config.helper_data
     helper_data["model"] = "model"
+    helper_data["tokenizer"] = "model"
     helper_data["model_parameters"] = "model_parameters"
     helper_data["model_kind"] = "model_kind"
     dataquality.finish(upload_model=True)


### PR DESCRIPTION
**Description:**
Currently we don't save the tokenizer when uploading a model

If a custom model is used besides distill-bert we cant reconstruct the tokenizer