### PR TITLE
fix(login): Use the correct name in login message

### DIFF
--- a/dataquality/core/auth.py
+++ b/dataquality/core/auth.py
@@ -26,8 +26,8 @@ class _Auth:
             webbrowser.open(token_url)
         except Exception:
             pass
-        print(f"Go to {token_url} to generate a new API Key")
-        access_token = getpass.getpass("🔐 Enter your API Key:")
+        print(f"Go to {token_url} to generate a new Galileo token.")
+        access_token = getpass.getpass("🔐 Enter your Galileo token: ")
         config.token = access_token
         config.update_file_config()
 


### PR DESCRIPTION
We have been calling JWT tokens API keys...