### PR TITLE
feat(core): Remove `is_public` from project creation

### DIFF
--- a/dataquality/clients/api.py
+++ b/dataquality/clients/api.py
@@ -226,9 +226,9 @@ class ApiClient:
         proj_resp = self.make_request(RequestType.PUT, url=url, body=data)
         return proj_resp if proj_resp else {}
 
-    def create_project(self, project_name: str, is_public: bool = False) -> Dict:
+    def create_project(self, project_name: str) -> Dict:
         """Creates a project given a name and returns the project information"""
-        body = {"name": project_name, "is_public": is_public}
+        body = {"name": project_name}
         return self.make_request(
             RequestType.POST, url=f"{config.api_url}/{Route.projects}", body=body
         )

--- a/dataquality/core/init.py
+++ b/dataquality/core/init.py
@@ -39,9 +39,7 @@ class InitManager:
         wait=wait_exponential_jitter(initial=0.1, max=2),
         stop=stop_after_attempt(5),
     )
-    def get_or_create_project(
-        self, project_name: str, is_public: bool
-    ) -> Tuple[Dict, bool]:
+    def get_or_create_project(self, project_name: str) -> Tuple[Dict, bool]:
         """Gets a project by name, or creates a new one if it doesn't exist.
 
         Returns:
@@ -51,12 +49,11 @@ class InitManager:
         project = api_client.get_project_by_name(project_name)
         created = False
         if not project:
-            project = api_client.create_project(project_name, is_public=is_public)
+            project = api_client.create_project(project_name)
             created = True
 
-        visibility = "public" if is_public else "private"
         created_str = "new" if created else "existing"
-        print(f"✨ Initializing {created_str} {visibility} project '{project_name}'")
+        print(f"✨ Initializing {created_str} project '{project_name}'")
         return project, created
 
     def get_or_create_run(
@@ -149,7 +146,6 @@ def init(
     task_type: str,
     project_name: Optional[str] = None,
     run_name: Optional[str] = None,
-    is_public: bool = True,
     overwrite_local: bool = True,
 ) -> None:
     """
@@ -174,7 +170,6 @@ def init(
     :param run_name: The run name. If not passed in, a random one will be
     generated. If provided, and the project does not exist, it will be created. If it
     does exist, it will be set.
-    :param is_public: Boolean value that sets the project's visibility. Default True.
     :param overwrite_local: If True, the current project/run log directory will be
     cleared during this function. If logging over many sessions with checkpoints, you
     may want to set this to False. Default True
@@ -194,7 +189,7 @@ def init(
         return
 
     project_name = validate_name(project_name, assign_random=True)
-    project, proj_created = _init.get_or_create_project(project_name, is_public)
+    project, proj_created = _init.get_or_create_project(project_name)
 
     if not run_name:
         run_name = create_run_name(project_name)

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -61,7 +61,7 @@ def test_init(
     assert config.current_project_id == test_session_vars.DEFAULT_PROJECT_ID
 
     mock_get_project_by_name.assert_called_once_with(ANY)
-    mock_create_project.assert_called_once_with(ANY, is_public=True)
+    mock_create_project.assert_called_once_with(ANY)
     mock_get_project_run_by_name.assert_called_once_with(ANY, ANY)
     # assert run is created with right task type
     mock_create_run.assert_called_once_with(ANY, ANY, task_type=TaskType[task_type])
@@ -90,40 +90,6 @@ def test_init_reset_logger_config(
     dataquality.set_labels_for_run(["a", "b", "c", "d"])
     dataquality.init(task_type="text_classification")
     assert not dataquality.get_data_logger().logger_config.labels
-
-
-@patch.object(ApiClient, "get_project_by_name", return_value={})
-@patch.object(ApiClient, "create_project")
-@patch.object(ApiClient, "get_project_run_by_name", return_value={})
-@patch.object(ApiClient, "create_run")
-@patch("dataquality.core.init._check_dq_version")
-@patch.object(dataquality.core.init.ApiClient, "valid_current_user", return_value=True)
-@patch("dataquality.core.init.create_run_name", return_value="foo")
-def test_init_new_private_project(
-    mock_create_run_name: MagicMock,
-    mock_valid_user: MagicMock,
-    mock_check_dq_version: MagicMock,
-    mock_create_run: MagicMock,
-    mock_get_project_run_by_name: MagicMock,
-    mock_create_project: MagicMock,
-    mock_get_project_by_name: MagicMock,
-    set_test_config: Callable,
-    test_session_vars: TestSessionVariables,
-) -> None:
-    """Base case: Tests creating a new project and run"""
-    mock_create_project.return_value = {"id": test_session_vars.DEFAULT_PROJECT_ID}
-    mock_create_run.return_value = {"id": test_session_vars.DEFAULT_RUN_ID}
-
-    dataquality.init(task_type="text_classification", is_public=False)
-    assert config.current_run_id == test_session_vars.DEFAULT_RUN_ID
-    assert config.current_project_id == test_session_vars.DEFAULT_PROJECT_ID
-
-    mock_get_project_by_name.assert_called_once_with(ANY)
-    mock_create_project.assert_called_once_with(ANY, is_public=False)
-    mock_get_project_run_by_name.assert_called_once_with(ANY, ANY)
-    mock_create_run.assert_called_once_with(
-        ANY, ANY, task_type=TaskType["text_classification"]
-    )
 
 
 @patch.object(ApiClient, "get_project_by_name")
@@ -190,7 +156,7 @@ def test_init_new_project(
     assert config.current_project_id == test_session_vars.DEFAULT_PROJECT_ID
 
     mock_get_project_by_name.assert_called_once_with("new_proj")
-    mock_create_project.assert_called_once_with("new_proj", is_public=True)
+    mock_create_project.assert_called_once_with("new_proj")
     mock_get_project_run_by_name.assert_called_once_with("new_proj", ANY)
     mock_create_run.assert_called_once_with(
         "new_proj", ANY, task_type=TaskType["text_classification"]
@@ -299,7 +265,7 @@ def test_init_new_project_run(
     assert config.current_project_id == test_session_vars.DEFAULT_PROJECT_ID
 
     mock_get_project_by_name.assert_called_once_with("new_proj")
-    mock_create_project.assert_called_once_with("new_proj", is_public=True)
+    mock_create_project.assert_called_once_with("new_proj")
     mock_get_project_run_by_name.assert_called_once_with("new_proj", "new_run")
     mock_create_run.assert_called_once_with(
         "new_proj", "new_run", task_type=TaskType["text_classification"]


### PR DESCRIPTION
The `is_public` field has been replaced by sharing projects with users
and groups.
